### PR TITLE
use x-rh-identity that came in with message for resource creation

### DIFF
--- a/sources/api_client.go
+++ b/sources/api_client.go
@@ -20,11 +20,11 @@ var xRhIdentity = `{"identity": {"account_number": "$ACCT$", "user": {"is_org_ad
 
 // NewAPIClient - creates a sources api client with default header for account
 // returns: Sources API Client
-func NewAPIClient(acct string) *sourcesapi.APIClient {
+func NewAPIClient(identityHeader string) *sourcesapi.APIClient {
 	conf := config.Get()
 
 	return sourcesapi.NewAPIClient(&sourcesapi.Configuration{
-		DefaultHeader: map[string]string{"x-rh-identity": encodedIdentity(acct)},
+		DefaultHeader: map[string]string{"x-rh-identity": identityHeader},
 		Servers: []sourcesapi.ServerConfiguration{
 			{
 				URL: fmt.Sprintf("%s://%s:%d/api/sources/v3.1", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort),

--- a/superkey/create_request.go
+++ b/superkey/create_request.go
@@ -12,8 +12,8 @@ import (
 // MarkSourceUnavailable marks the application and source as unavailable, while
 // also marking the application's availability_status_error to what AWS updated
 // us with.
-func (req *CreateRequest) MarkSourceUnavailable(err error, newApplication *ForgedApplication) error {
-	client := sources.NewAPIClient(req.TenantID)
+func (req *CreateRequest) MarkSourceUnavailable(err error, newApplication *ForgedApplication, identityHeader string) error {
+	client := sources.NewAPIClient(identityHeader)
 	availabilityStatus := "unavailable"
 	availabilityStatusError := fmt.Sprintf("Resource Creation erorr: failed to create resources in amazon, error: %v", err)
 	extra := make(map[string]interface{})

--- a/superkey/forged_application.go
+++ b/superkey/forged_application.go
@@ -30,8 +30,8 @@ func (f *ForgedApplication) MarkCompleted(name string, data map[string]string) {
 }
 
 // CreateInSourcesAPI - creates the forged application in sources
-func (f *ForgedApplication) CreateInSourcesAPI() error {
-	client := sources.NewAPIClient(f.Request.TenantID)
+func (f *ForgedApplication) CreateInSourcesAPI(identityHeader string) error {
+	client := sources.NewAPIClient(identityHeader)
 
 	l.Log.Info("Sleeping to prevent IAM Race Condition")
 	// IAM is slow, this prevents the race condition of the POST happening


### PR DESCRIPTION
Found out when integrating with cost that we can't just use a dummy header when creating resources, so this PR combined with a sources-api PR to pass along headers fixes it. 

We'll just use the x-rh-id header that is passed along for making requests. 

cc @syncrou this should be the last bit for full cost superkey support. 
