### PR TITLE
Log to STD error and use haberdasher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,10 @@ RUN go build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-291
 COPY --from=build /build/sources-superkey-worker /sources-superkey-worker
-ENTRYPOINT ["/sources-superkey-worker"]
+
+RUN curl -L -o /usr/bin/haberdasher \
+    https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
+    chmod 755 /usr/bin/haberdasher
+
+ENTRYPOINT ["/usr/bin/haberdasher"]
+CMD ["/sources-superkey-worker"]

--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ func Get() *SuperKeyWorkerConfig {
 	options.SetDefault("KafkaGroupID", "sources-superkey-worker")
 	options.SetDefault("KafkaTopics", kafkaTopics)
 	options.SetDefault("LogLevel", "INFO")
-    options.SetDefault("LogHandler", os.Getenv("LOG_HANDLER"))
+	options.SetDefault("LogHandler", os.Getenv("LOG_HANDLER"))
 
 	options.SetDefault("SourcesHost", os.Getenv("SOURCES_HOST"))
 	options.SetDefault("SourcesScheme", os.Getenv("SOURCES_SCHEME"))
@@ -76,7 +76,7 @@ func Get() *SuperKeyWorkerConfig {
 		KafkaGroupID:       options.GetString("KafkaGroupID"),
 		MetricsPort:        options.GetInt("MetricsPort"),
 		LogLevel:           options.GetString("LogLevel"),
-        LogHandler:         options.GetString("LogHandler"),
+		LogHandler:         options.GetString("LogHandler"),
 		LogGroup:           options.GetString("LogGroup"),
 		AwsRegion:          options.GetString("AwsRegion"),
 		AwsAccessKeyID:     options.GetString("AwsAccessKeyID"),

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type SuperKeyWorkerConfig struct {
 	MetricsPort        int
 	LogLevel           string
 	LogGroup           string
+	LogHandler         string
 	AwsRegion          string
 	AwsAccessKeyID     string
 	AwsSecretAccessKey string
@@ -57,6 +58,7 @@ func Get() *SuperKeyWorkerConfig {
 	options.SetDefault("KafkaGroupID", "sources-superkey-worker")
 	options.SetDefault("KafkaTopics", kafkaTopics)
 	options.SetDefault("LogLevel", "INFO")
+    options.SetDefault("LogHandler", os.Getenv("LOG_HANDLER"))
 
 	options.SetDefault("SourcesHost", os.Getenv("SOURCES_HOST"))
 	options.SetDefault("SourcesScheme", os.Getenv("SOURCES_SCHEME"))
@@ -74,6 +76,7 @@ func Get() *SuperKeyWorkerConfig {
 		KafkaGroupID:       options.GetString("KafkaGroupID"),
 		MetricsPort:        options.GetInt("MetricsPort"),
 		LogLevel:           options.GetString("LogLevel"),
+        LogHandler:         options.GetString("LogHandler"),
 		LogGroup:           options.GetString("LogGroup"),
 		AwsRegion:          options.GetString("AwsRegion"),
 		AwsAccessKeyID:     options.GetString("AwsAccessKeyID"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -21,12 +21,20 @@ objects:
           value: ${DISABLE_RESOURCE_CREATION}
         - name: DISABLE_RESOURCE_DELETION
           value: ${DISABLE_RESOURCE_DELETION}
+        - name: HABERDASHER_EMITTER
+          value: ${HABERDASHER_EMITTER}
+        - name: HABERDASHER_KAFKA_BOOTSTRAP
+          value: ${HABERDASHER_KAFKA_BOOTSTRAP}
+        - name: HABERDASHER_KAFKA_TOPIC
+          value: ${HABERDASHER_KAFKA_TOPIC}
         - name: SOURCES_SCHEME
           value: ${SOURCES_SCHEME}
         - name: SOURCES_HOST
           value: ${SOURCES_HOST}
         - name: SOURCES_PORT
-          value: ${SOURCES_PORT}        
+          value: ${SOURCES_PORT}
+        - name: LOG_HANDLER
+          value: ${LOG_HANDLER}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -50,11 +58,22 @@ parameters:
 - description: Clowder ENV
   name: ENV_NAME
   required: true
+- description: Emitter for haberdasher logs [stderr|kafka]
+  name: HABERDASHER_EMITTER
+  value: stderr
+- description: Bootstrap server for haberdasher kafka emitter
+  name: HABERDASHER_KAFKA_BOOTSTRAP
+  value: ''
+- description: Kafka topic for haberdasher kafka emitter
+  name: HABERDASHER_KAFKA_TOPIC
+  value: ''
 - description: Image
   name: IMAGE
   value: quay.io/cloudservices/sources-superkey-worker
 - name: IMAGE_TAG
-  value: latest   
+  value: latest
+- name: LOG_HANDLER
+  value: 'haberdasher'
 - name: LOG_LEVEL
   value: WARN    
 - name: MEMORY_LIMIT

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -110,7 +110,9 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 	formatter := NewCustomLoggerFormatter()
 
     logOutput := os.Stdout
-    if ForwardLogsToStderr(cfg.LogHandler) {
+    forwardLogsToStderr := ForwardLogsToStderr(cfg.LogHandler)
+
+    if forwardLogsToStderr {
         logOutput = os.Stderr
     }
 
@@ -121,6 +123,10 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 		Hooks:        make(logrus.LevelHooks),
 		ReportCaller: true,
 	}
+
+    if forwardLogsToStderr {
+        return Log
+    }
 
 	// TODO: maybe redo this to work with the go-aws-v2 library.
 	// That would involve updating the platform middleware though, which might

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -72,7 +72,12 @@ func (f *CustomCloudwatch) Format(entry *logrus.Entry) ([]byte, error) {
 
 	b.Write(j)
 
+    b.Write([]byte("\n"))
 	return b.Bytes(), nil
+}
+
+func ForwardLogsToStderr(logHandler string) bool {
+    return logHandler == "haberdasher"
 }
 
 // InitLogger initializes the Sources SuperKey logger
@@ -101,8 +106,13 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 
 	formatter := NewCloudwatchFormatter()
 
+    logOutput := os.Stdout
+    if ForwardLogsToStderr(cfg.LogHandler) {
+        logOutput = os.Stderr
+    }
+
 	Log = &logrus.Logger{
-		Out:          os.Stdout,
+		Out:          logOutput,
 		Level:        logLevel,
 		Formatter:    formatter,
 		Hooks:        make(logrus.LevelHooks),

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -21,7 +21,7 @@ var logLevel logrus.Level
 
 // NewCustomLoggerFormatter creates a new log formatter
 func NewCustomLoggerFormatter() *CustomLoggerFormatter {
-	f := &CustomLoggerFormatter{}
+	f := &CustomLoggerFormatter{AppName: "sources-superkey-worker"}
 
 	var err error
 	if f.Hostname == "" {
@@ -48,10 +48,13 @@ func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		"@timestamp": now.Format("2006-01-02T15:04:05.999Z"),
 		"@version":   1,
 		"message":    entry.Message,
-		"levelname":  entry.Level.String(),
+		"levelname":  entry.Level.String(), //Backward compatibility - TODO: remove?
+		"level":      entry.Level.String(),
 		"hostname":   f.Hostname,
-		"app":        "sources-superkey-worker",
+		"app":        f.AppName,
 		"caller":     entry.Caller.Func.Name(),
+		"labels":     map[string]interface{}{"app" : f.AppName},
+		"tags":       []string{f.AppName},
 	}
 
 	for k, v := range entry.Data {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -19,9 +19,9 @@ import (
 var Log *logrus.Logger
 var logLevel logrus.Level
 
-// NewCloudwatchFormatter creates a new log formatter
-func NewCloudwatchFormatter() *CustomCloudwatch {
-	f := &CustomCloudwatch{}
+// NewCustomLoggerFormatter creates a new log formatter
+func NewCustomLoggerFormatter() *CustomLoggerFormatter {
+	f := &CustomLoggerFormatter{}
 
 	var err error
 	if f.Hostname == "" {
@@ -34,7 +34,7 @@ func NewCloudwatchFormatter() *CustomCloudwatch {
 }
 
 //Format is the log formatter for the entry
-func (f *CustomCloudwatch) Format(entry *logrus.Entry) ([]byte, error) {
+func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 
 	now := time.Now()
@@ -104,7 +104,7 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 		logLevel = logrus.FatalLevel
 	}
 
-	formatter := NewCloudwatchFormatter()
+	formatter := NewCustomLoggerFormatter()
 
     logOutput := os.Stdout
     if ForwardLogsToStderr(cfg.LogHandler) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -79,7 +79,7 @@ func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func ForwardLogsToStderr(logHandler string) bool {
+func forwardLogsToStderr(logHandler string) bool {
     return logHandler == "haberdasher"
 }
 
@@ -110,9 +110,8 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 	formatter := NewCustomLoggerFormatter()
 
     logOutput := os.Stdout
-    forwardLogsToStderr := ForwardLogsToStderr(cfg.LogHandler)
 
-    if forwardLogsToStderr {
+    if forwardLogsToStderr(cfg.LogHandler) {
         logOutput = os.Stderr
     }
 
@@ -124,14 +123,10 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 		ReportCaller: true,
 	}
 
-    if forwardLogsToStderr {
-        return Log
-    }
-
 	// TODO: maybe redo this to work with the go-aws-v2 library.
 	// That would involve updating the platform middleware though, which might
 	// not be fun.
-	if key != "" && secret != "" {
+	if key != "" && secret != "" && !forwardLogsToStderr(cfg.LogHandler) {
 		cred := credentials.NewStaticCredentials(key, secret, "")
 		awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 		hook, err := lc.NewBatchingHook(group, stream, awsconf, 10*time.Second)

--- a/logger/types.go
+++ b/logger/types.go
@@ -1,7 +1,7 @@
 package logger
 
-// CustomCloudwatch adds hostname and app name
-type CustomCloudwatch struct {
+// NewCustomLoggerFormatter adds hostname and app name
+type CustomLoggerFormatter struct {
 	Hostname string
 }
 

--- a/logger/types.go
+++ b/logger/types.go
@@ -3,6 +3,7 @@ package logger
 // NewCustomLoggerFormatter adds hostname and app name
 type CustomLoggerFormatter struct {
 	Hostname string
+	AppName string
 }
 
 //Marshaler is an interface any type can implement to change its output in our production logs.


### PR DESCRIPTION
- Switch between existing logging and logging to std err which is consumed by haberdasher.
- LOG_HANDLER = haberdasher -  logging to std err
  - otherwise log as it was
- improved log format - especially added labels and tags - which is used for filtering/forwarding in logging service


### Links

https://issues.redhat.com/browse/RHCLOUD-13753
https://github.com/RedHatInsights/sources-api/issues/392


cc @slemrmartin @lindgrenj6 
