### PR TITLE
BugFixes for cost creation + error on s3 bucket deletion

### DIFF
--- a/provider/amazon_provider.go
+++ b/provider/amazon_provider.go
@@ -71,6 +71,8 @@ func (a *AmazonProvider) ForgeApplication(request *superkey.CreateRequest) (*sup
 				return f, err
 			}
 
+			costReport.ReportName = fmt.Sprintf("%v-%v", costReport.ReportName, f.GUID)
+
 			l.Log.Infof("Create Cost and Usage Report: %v", costReport.ReportName)
 			err = a.Client.CreateCostAndUsageReport(&costReport)
 			if err != nil {


### PR DESCRIPTION
There are two bugfixes in this PR (in 2 commits to make it easier to see)

1. During s3 bucket deletion there was potential for a panic if there was an error along the way due to a nil pointer dereference on the `for _, err := range object.Contents` field. I changed it to just bail and error early rather than trying to continue and get more errors (because if we can't clean up the ocntents -> we definitely won't be able to delete the bucket.
2. There was potential for a name collision on the cost and usage report creation process, and upon asking Doug if the name mattered it turns out it does not, they just need the s3 bucket name. So I am now appending the GUID from the application to the name, that way there shouldn't be collisions anymore. 