### PR TITLE
Revert "Destroy the created cost and usage report on teardown"

### DIFF
--- a/provider/amazon_provider.go
+++ b/provider/amazon_provider.go
@@ -182,20 +182,6 @@ func (a *AmazonProvider) TearDown(f *superkey.ForgedApplication) []error {
 	errors := make([]error, 0)
 
 	// -----------------
-	// destroy the cost and usage report first
-	// -----------------
-	if f.StepsCompleted["cost_report"] != nil {
-		reportName := f.StepsCompleted["cost_report"]["output"]
-		err := a.Client.DestroyCostAndUsageReport(reportName)
-		if err != nil {
-			l.Log.Warnf("Failed to delete cost report %v", reportName)
-			errors = append(errors, err)
-		}
-
-		l.Log.Infof("Deleted cost report %v", reportName)
-	}
-
-	// -----------------
 	// unbind the role first (if it happened) so we can cleanly delete the policy and the role.
 	// -----------------
 	if f.StepsCompleted["bind_role"] != nil {


### PR DESCRIPTION
This reverts commit e8571a1d796e2ed9c509615f80f2401004729fbb.

Reverting #31 since we already do it here: https://github.com/RedHatInsights/sources-superkey-worker/blob/60641202df465b02fd6779c050dbd09cd6ce4e50/provider/amazon_provider.go#L241-L251

Not sure why the account has so many instances attached to it - but we _should_ be clearing them out fine. 