### PR TITLE
Add Liveness + Readiness Probes for AppSRE

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -42,6 +42,19 @@ objects:
           requests:
             cpu: ${CPU_REQUEST}
             memory: ${MEMORY_REQUEST}
+        readinessProbe:
+          exec:
+            command:
+              - stat
+              - /tmp/healthy
+          initialDelaySeconds: 3
+        livenessProbe:
+          exec:
+            command:
+              - stat
+              - /tmp/healthy
+          initialDelaySeconds: 10
+          periodSeconds: 10
     kafkaTopics:
     - topicName: platform.sources.superkey-requests
       partitions: 3


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-15152

Pretty self-explanatory. But I will re-iterate:

I have a loop that runs in a goroutine forever, every 10 seconds it tries to hit s3/iam AWS APIs. If it can -> we touch a /tmp/healthy file first. That file will sit there forever, until we cannot hit an API. Once that happens we remove the file.

The liveness/readiness probes just run `stat /tmp/healthy` repeatedly. If the file is _not_ there that exits with status 1, letting openshift know the pod is unhealthy. If that happens 3 times in a row (e.g. the AWS api is failing for 30 seconds), it will bounce the pod for us. This will be handy if DNS suddenly dies on the cluster. 
