### PR TITLE
Test warn, error level in Kibana

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -73,7 +73,7 @@ parameters:
 - name: IMAGE_TAG
   value: latest
 - name: LOG_HANDLER
-  value: 'haberdasher'
+  value: 'built-in'
 - name: LOG_LEVEL
   value: WARN    
 - name: MEMORY_LIMIT

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -48,7 +48,6 @@ func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		"@timestamp": now.Format("2006-01-02T15:04:05.999Z"),
 		"@version":   1,
 		"message":    entry.Message,
-		"levelname":  entry.Level.String(), //Backward compatibility - TODO: remove?
 		"level":      entry.Level.String(),
 		"hostname":   f.Hostname,
 		"app":        f.AppName,

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func main() {
 	l.Log.Infof("Talking to Sources API at: %v", fmt.Sprintf("%v://%v:%v", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort))
 
 	l.Log.Info("SuperKey Worker started.")
+	l.Log.Warnf("SuperKey Worker started.")  // TODO: remove - this for testing reasons
+	l.Log.Errorf("SuperKey Worker started.") // TODO: remove - this for testing reasons
 
 	// returns real topic name from config (identical in local and app-interface mode)
 	requestQueue, found := conf.KafkaTopics[SuperKeyRequestQueue]


### PR DESCRIPTION
- set log level In `level` attribute - this was done I just removed unnecessary `levelname`
- Test warn, error level on startup to confirm whether are delivered to Kibana successfully
- turn off usage of haberdasher so we can test origin way.

As we have set LOG_LEVEL to WARN, usage of `level` attribute should cause that we will have in Kibana only log messages with warning and error.