### PR TITLE
Add Azure Provider for lighthouse enabled customers (crawl phase)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205 as build
-MAINTAINER jlindgre@redhat.com
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-210 as build
 
 RUN mkdir /build
 WORKDIR /build
@@ -7,17 +6,17 @@ WORKDIR /build
 RUN microdnf install go
 
 COPY go.mod .
-RUN go mod download 
+RUN go mod download
 
 COPY . .
 RUN go build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-210
 COPY --from=build /build/sources-superkey-worker /sources-superkey-worker
 
-RUN curl -L -o /usr/bin/haberdasher \
-    https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
-    chmod 755 /usr/bin/haberdasher
+# install az cli from micro$oft
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
+    echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" | tee /etc/yum.repos.d/azure-cli.repo && \
+    microdnf install azure-cli
 
-ENTRYPOINT ["/usr/bin/haberdasher"]
-CMD ["/sources-superkey-worker"]
+ENTRYPOINT ["/sources-superkey-worker"]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ container:
 run: build
 	./sources-superkey-worker
 
+inlinerun:
+	go run *.go
+
 fancyrun: build
 	./sources-superkey-worker | grep '^{' | jq -r .
 
@@ -34,4 +37,4 @@ lint:
 gci:
 	golangci-lint run -E gci --fix
 
-.PHONY: build container run fancyrun runcontainer clean debug tidy debug remotedebug lint gci
+.PHONY: build container run fancyrun runcontainer clean debug tidy debug remotedebug lint gci inlinerun

--- a/azure/az_cli.go
+++ b/azure/az_cli.go
@@ -31,13 +31,12 @@ func (cli *AzCli) DeploySubscriptionTemplate(name, path string) (string, error) 
 
 	cmd.Env = cli.generatedEnv()
 
-	err := cmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("failed to run [az deployment sub create] command: %v", err)
-	}
+	// explicitly ignoring the error - since we want to POST back the error
+	// message if there was a problem.
+	_ = cmd.Run()
 
 	l.Log.Infof("running [az deployment sub show]")
-	cmd = exec.CommandContext(ctx, "az", "deployment", "sub", "show", fmt.Sprintf("-n=%v", name))
+	cmd = exec.CommandContext(ctx, "az", "deployment", "sub", "show", fmt.Sprintf("--name=%v", name))
 	cmd.Env = cli.generatedEnv()
 
 	output, err := cmd.Output()
@@ -50,6 +49,16 @@ func (cli *AzCli) DeploySubscriptionTemplate(name, path string) (string, error) 
 	err = json.Unmarshal(output, &azDeploy)
 	if err != nil {
 		return "", fmt.Errorf("failed to unmarshal subscription output: %v", err)
+	}
+
+	if azDeploy.Properties.Error.Code != "" {
+		// extract the error doc from the message since it's embedded...oof
+		emsg := getErrorMessageFromError(azDeploy.Properties.Error.Details[0].Message)
+		if emsg == "" {
+			return "", fmt.Errorf("error during deployment: %v", azDeploy.Properties.Error.Code)
+		} else {
+			return "", fmt.Errorf("error during deployment: %v", emsg)
+		}
 	}
 
 	l.Log.Infof("parsing uuid from susbcription id")
@@ -83,9 +92,13 @@ func (cli *AzCli) DeleteSubscription(name string) error {
 	return nil
 }
 
-func (cli *AzCli) Login(username, password string) error {
+func (cli *AzCli) Login(username, password, tenant string) error {
 	l.Log.Infof("running [az login]")
-	cmd := exec.Command("az", "login", fmt.Sprintf("--username=%v", username), fmt.Sprintf("--password=%v", password))
+	cmd := exec.Command("az", "login", "--service-principal",
+		fmt.Sprintf("--username=%v", username),
+		fmt.Sprintf("--password=%v", password),
+		fmt.Sprintf("--tenant=%v", tenant),
+	)
 	cmd.Env = cli.generatedEnv()
 
 	if err := cmd.Run(); err != nil {
@@ -107,9 +120,12 @@ func (cli *AzCli) Logout() error {
 	return nil
 }
 
-func (cli *AzCli) Cleanup() error {
+func (cli *AzCli) Cleanup() {
 	l.Log.Infof("removing tmpdir [%v]", cli.HomeDirectory)
-	return os.RemoveAll(cli.HomeDirectory)
+	err := os.RemoveAll(cli.HomeDirectory)
+	if err != nil {
+		l.Log.Warnf("failed to remove tmpdir [%v], potentially dangling credentials.", cli.HomeDirectory)
+	}
 }
 
 func (cli *AzCli) generatedEnv() []string {
@@ -117,6 +133,7 @@ func (cli *AzCli) generatedEnv() []string {
 }
 
 var subscriptionIDRegex = regexp.MustCompile(`/subscriptions/(.*)/providers/`)
+var errorMessageRegex = regexp.MustCompile(`{.*}`)
 
 func getUuidFromSubscription(sub string) string {
 	if !subscriptionIDRegex.MatchString(sub) {
@@ -125,4 +142,20 @@ func getUuidFromSubscription(sub string) string {
 
 	matches := subscriptionIDRegex.FindAllStringSubmatch(sub, 1)
 	return matches[1][0]
+}
+
+func getErrorMessageFromError(e string) string {
+	if !errorMessageRegex.MatchString(e) {
+		return ""
+	}
+
+	matches := errorMessageRegex.FindAllSubmatch([]byte(e), 1)
+	errJson := AzureDeploymentErrorJson{}
+
+	err := json.Unmarshal(matches[0][0], &errJson)
+	if err != nil {
+		return ""
+	}
+
+	return errJson.OdataError.Message.Value
 }

--- a/azure/az_cli.go
+++ b/azure/az_cli.go
@@ -1,0 +1,128 @@
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"time"
+
+	l "github.com/redhatinsights/sources-superkey-worker/logger"
+)
+
+type AzCli struct {
+	HomeDirectory string
+}
+
+func (cli *AzCli) DeploySubscriptionTemplate(name, path string) (string, error) {
+	l.Log.Infof("running [az deployment sub create]")
+
+	// set a timeout of 5 minutes for the subshell.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
+		"az", "deployment", "sub", "create",
+		"--location=WestUS",
+		fmt.Sprintf("--name=%v", name),
+		fmt.Sprintf("--template-file=%v", path))
+
+	cmd.Env = cli.generatedEnv()
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to run [az deployment sub create] command: %v", err)
+	}
+
+	l.Log.Infof("running [az deployment sub show]")
+	cmd = exec.CommandContext(ctx, "az", "deployment", "sub", "show", fmt.Sprintf("-n=%v", name))
+	cmd.Env = cli.generatedEnv()
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run [az deployment sub show] command: %v", err)
+	}
+
+	l.Log.Infof("unmarshaling output into struct")
+	azDeploy := AzureDeployment{}
+	err = json.Unmarshal(output, &azDeploy)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal subscription output: %v", err)
+	}
+
+	l.Log.Infof("parsing uuid from susbcription id")
+	subID := getUuidFromSubscription(azDeploy.ID)
+
+	if subID == "" {
+		return "", fmt.Errorf("failed to parse uuid from subscription ID: %v", azDeploy.ID)
+	}
+
+	return subID, nil
+}
+
+func (cli *AzCli) DeleteSubscription(name string) error {
+	// set a timeout of 5 minutes for the subshell.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	l.Log.Infof("running [az deployment sub delete]")
+	cmd := exec.CommandContext(ctx,
+		"az", "deployment", "sub", "delete",
+		fmt.Sprintf("--name=%v", name),
+	)
+
+	cmd.Env = cli.generatedEnv()
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run [az deployment sub delete] command: %v", err)
+	}
+
+	return nil
+}
+
+func (cli *AzCli) Login(username, password string) error {
+	l.Log.Infof("running [az login]")
+	cmd := exec.Command("az", "login", fmt.Sprintf("--username=%v", username), fmt.Sprintf("--password=%v", password))
+	cmd.Env = cli.generatedEnv()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to login with az credentials: %v", err.Error())
+	}
+
+	return nil
+}
+
+func (cli *AzCli) Logout() error {
+	l.Log.Infof("running [az logout]")
+	cmd := exec.Command("az", "logout")
+	cmd.Env = cli.generatedEnv()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to logout az cli: %v", err.Error())
+	}
+
+	return nil
+}
+
+func (cli *AzCli) Cleanup() error {
+	l.Log.Infof("removing tmpdir [%v]", cli.HomeDirectory)
+	return os.RemoveAll(cli.HomeDirectory)
+}
+
+func (cli *AzCli) generatedEnv() []string {
+	return []string{fmt.Sprintf("HOME=%v", cli.HomeDirectory)}
+}
+
+var subscriptionIDRegex = regexp.MustCompile(`/subscriptions/(.*)/providers/`)
+
+func getUuidFromSubscription(sub string) string {
+	if !subscriptionIDRegex.MatchString(sub) {
+		return ""
+	}
+
+	matches := subscriptionIDRegex.FindAllStringSubmatch(sub, 1)
+	return matches[1][0]
+}

--- a/azure/types.go
+++ b/azure/types.go
@@ -88,3 +88,15 @@ type AzureDeployment struct {
 	Tags interface{} `json:"tags"`
 	Type string      `json:"type"`
 }
+
+type AzureDeploymentErrorJson struct {
+	OdataError struct {
+		Code    string `json:"code"`
+		Message struct {
+			Lang  string `json:"lang"`
+			Value string `json:"value"`
+		} `json:"message"`
+		RequestID string `json:"requestId"`
+		Date      string `json:"date"`
+	} `json:"odata.error"`
+}

--- a/azure/types.go
+++ b/azure/types.go
@@ -1,0 +1,90 @@
+package azure
+
+import "time"
+
+type AzureDeploymentOutput []AzureDeployment
+type AzureDeployment struct {
+	ID         string `json:"id"`
+	Location   string `json:"location"`
+	Name       string `json:"name"`
+	Properties struct {
+		CorrelationID string      `json:"correlationId"`
+		DebugSetting  interface{} `json:"debugSetting"`
+		Dependencies  []struct {
+			DependsOn []struct {
+				ID           string `json:"id"`
+				ResourceName string `json:"resourceName"`
+				ResourceType string `json:"resourceType"`
+			} `json:"dependsOn"`
+			ID           string `json:"id"`
+			ResourceName string `json:"resourceName"`
+			ResourceType string `json:"resourceType"`
+		} `json:"dependencies"`
+		Duration string `json:"duration"`
+		Error    struct {
+			AdditionalInfo interface{} `json:"additionalInfo"`
+			Code           string      `json:"code"`
+			Details        []struct {
+				AdditionalInfo interface{} `json:"additionalInfo"`
+				Code           string      `json:"code"`
+				Details        interface{} `json:"details"`
+				Message        string      `json:"message"`
+				Target         interface{} `json:"target"`
+			} `json:"details"`
+			Message string      `json:"message"`
+			Target  interface{} `json:"target"`
+		} `json:"error"`
+		Mode              string      `json:"mode"`
+		OnErrorDeployment interface{} `json:"onErrorDeployment"`
+		OutputResources   interface{} `json:"outputResources"`
+		Outputs           interface{} `json:"outputs"`
+		Parameters        struct {
+			Authorizations struct {
+				Type  string `json:"type"`
+				Value []struct {
+					PrincipalID            string `json:"principalId"`
+					PrincipalIDDisplayName string `json:"principalIdDisplayName"`
+					RoleDefinitionID       string `json:"roleDefinitionId"`
+				} `json:"value"`
+			} `json:"authorizations"`
+			ManagedByTenantID struct {
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"managedByTenantId"`
+			MspOfferDescription struct {
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"mspOfferDescription"`
+			MspOfferName struct {
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"mspOfferName"`
+		} `json:"parameters"`
+		ParametersLink interface{} `json:"parametersLink"`
+		Providers      []struct {
+			ID                                interface{} `json:"id"`
+			Namespace                         string      `json:"namespace"`
+			ProviderAuthorizationConsentState interface{} `json:"providerAuthorizationConsentState"`
+			RegistrationPolicy                interface{} `json:"registrationPolicy"`
+			RegistrationState                 interface{} `json:"registrationState"`
+			ResourceTypes                     []struct {
+				Aliases           interface{}   `json:"aliases"`
+				APIProfiles       interface{}   `json:"apiProfiles"`
+				APIVersions       interface{}   `json:"apiVersions"`
+				Capabilities      interface{}   `json:"capabilities"`
+				DefaultAPIVersion interface{}   `json:"defaultApiVersion"`
+				LocationMappings  interface{}   `json:"locationMappings"`
+				Locations         []interface{} `json:"locations"`
+				Properties        interface{}   `json:"properties"`
+				ResourceType      string        `json:"resourceType"`
+			} `json:"resourceTypes"`
+		} `json:"providers"`
+		ProvisioningState  string      `json:"provisioningState"`
+		TemplateHash       string      `json:"templateHash"`
+		TemplateLink       interface{} `json:"templateLink"`
+		Timestamp          time.Time   `json:"timestamp"`
+		ValidatedResources interface{} `json:"validatedResources"`
+	} `json:"properties"`
+	Tags interface{} `json:"tags"`
+	Type string      `json:"type"`
+}

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -43,6 +43,10 @@ objects:
               optional: true
         - name: LOG_HANDLER
           value: ${LOG_HANDLER}
+        - name: CLOUD_METER_URL
+          value: ${CLOUD_METER_API_SCHEME}://${CLOUD_METER_API_HOST}:${CLOUD_METER_API_PORT}
+        - name: CLOUD_METER_SYSCONFIG_PATH
+          value: ${CLOUD_METER_SYSCONFIG_PATH}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -118,3 +122,16 @@ parameters:
   displayName: Sources Service Port
   description: Port to use for the Sources service URL.
   value: "8000"
+- description: Scheme of the Cloud Meter API
+  displayName: Cloud Meter API Scheme
+  name: CLOUD_METER_API_SCHEME
+  value: http
+- description: Hostname of the Cloud Meter API
+  displayName: Cloud Meter API Hostname
+  name: CLOUD_METER_API_HOST
+  required: true
+  value: cloudigrade-api
+- name: CLOUD_METER_API_PORT
+  value: '8000'
+- name: CLOUD_METER_SYSCONFIG_PATH
+  value: /api/cloudigrade/v2/sysconfig/

--- a/provider/amazon_provider.go
+++ b/provider/amazon_provider.go
@@ -1,8 +1,6 @@
 package provider
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -138,17 +136,6 @@ func (a *AmazonProvider) ForgeApplication(request *superkey.CreateRequest) (*sup
 	f.CreatePayload(&username, nil, &appType)
 
 	return f, nil
-}
-
-// generateGUID() generates a short guid for resources
-func generateGUID() (string, error) {
-	bytes := make([]byte, 8)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return "", err
-	}
-
-	return hex.EncodeToString(bytes), nil
 }
 
 // getShortName(string) generates a name off of the application type

--- a/provider/azure_provider.go
+++ b/provider/azure_provider.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
 	"path"
 
 	"github.com/redhatinsights/sources-superkey-worker/azure"
@@ -25,7 +25,7 @@ func (az *AzureProvider) ForgeApplication(request *superkey.CreateRequest) (*sup
 		return nil, err
 	}
 
-	tmpdir, err := os.MkdirTemp("/tmp/", "az")
+	tmpdir, err := ioutil.TempDir("/tmp/", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary home directory for az cli: %v", err.Error())
 	}
@@ -68,7 +68,7 @@ func (az *AzureProvider) ForgeApplication(request *superkey.CreateRequest) (*sup
 }
 
 func (az *AzureProvider) TearDown(f *superkey.ForgedApplication) []error {
-	tmpdir, err := os.MkdirTemp("/tmp/", "")
+	tmpdir, err := ioutil.TempDir("/tmp/", "")
 	if err != nil {
 		return []error{fmt.Errorf("failed to create temporary home directory for az cli: %v", err.Error())}
 	}

--- a/provider/azure_provider.go
+++ b/provider/azure_provider.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/redhatinsights/sources-superkey-worker/azure"
+	"github.com/redhatinsights/sources-superkey-worker/superkey"
+)
+
+type AzureProvider struct {
+	Username string
+	Password string
+}
+
+func (az *AzureProvider) ForgeApplication(request *superkey.CreateRequest) (*superkey.ForgedApplication, error) {
+	if !CloudigradeTemplateImported {
+		return nil, fmt.Errorf("cloudigrade azure template is not imported - resource creation impossible")
+	}
+
+	guid, err := generateGUID()
+	if err != nil {
+		return nil, err
+	}
+
+	tmpdir, err := os.MkdirTemp("/tmp/", "az")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary home directory for az cli: %v", err.Error())
+	}
+
+	f := &superkey.ForgedApplication{
+		StepsCompleted: make(map[string]map[string]string),
+		Request:        request,
+		Client:         az,
+		GUID:           guid,
+	}
+
+	name := fmt.Sprintf("redhat-cloudmeter-%v", guid)
+
+	// Create the struct that will manage running the create/destroy commands
+	cliInstance := azure.AzCli{HomeDirectory: tmpdir}
+	defer cliInstance.Cleanup()
+
+	err = cliInstance.Login(az.Username, az.Password)
+	if err != nil {
+		return f, err
+	}
+
+	subscriptionID, err := cliInstance.DeploySubscriptionTemplate(name, CLOUDIGRADE_AZURE_TEMPLATE_PATH)
+	if err != nil {
+		return f, err
+	}
+
+	err = cliInstance.Logout()
+	if err != nil {
+		return f, err
+	}
+
+	f.StepsCompleted["az-lighthouse"] = map[string]string{"name": name, "subscriptionID": subscriptionID}
+	appType := path.Base(f.Request.ApplicationType)
+	f.CreatePayload(&subscriptionID, nil, &appType)
+
+	return f, nil
+}
+
+func (az *AzureProvider) TearDown(f *superkey.ForgedApplication) []error {
+	tmpdir, err := os.MkdirTemp("/tmp/", "")
+	if err != nil {
+		return []error{fmt.Errorf("failed to create temporary home directory for az cli: %v", err.Error())}
+	}
+
+	name := f.StepsCompleted["az-lighthouse"]["name"]
+
+	// Create the struct that will manage running the create/destroy commands
+	cliInstance := azure.AzCli{HomeDirectory: tmpdir}
+	defer cliInstance.Cleanup()
+
+	err = cliInstance.Login(az.Username, az.Password)
+	if err != nil {
+		return []error{err}
+	}
+
+	err = cliInstance.DeleteSubscription(name)
+	if err != nil {
+		return []error{err}
+	}
+
+	err = cliInstance.Logout()
+	if err != nil {
+		return []error{err}
+	}
+
+	err = cliInstance.Cleanup()
+	if err != nil {
+		return []error{err}
+	}
+
+	return nil
+}

--- a/provider/cloudigrade_configs.go
+++ b/provider/cloudigrade_configs.go
@@ -3,19 +3,26 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	l "github.com/redhatinsights/sources-superkey-worker/logger"
 )
 
 var (
-	CLOUDIGRADE_AZURE_TEMPLATE_PATH = "/tmp/az_payload.json"
-	CLOUDIGRADE_AZURE_SECRET_PATH   = os.Getenv("AZURE_TEMPLATE_PATH")
+	CLOUDIGRADE_AZURE_TEMPLATE_PATH       = "/tmp/az_payload.json"
+	CLOUDIGRADE_AZURE_TEMPLATE_LOCAL_PATH = os.Getenv("AZURE_TEMPLATE_PATH")
+
+	CLOUDIGRADE_URL            = os.Getenv("CLOUD_METER_URL")
+	CLOUDIGRADE_SYSCONFIG_PATH = os.Getenv("CLOUD_METER_SYSCONFIG_PATH")
+
+	CloudigradeTemplateImported = false
+	CloudigradeConfig           *cloudigradeConfig
 )
 
-var CloudigradeTemplateImported = false
-
-type CloudigradeConfig struct {
+type cloudigradeConfig struct {
 	SysConfig     CloudigradeSysConfig
 	AzureTemplate string
 }
@@ -29,39 +36,41 @@ type CloudigradeSysConfig struct {
 	Version                string `json:"version"`
 }
 
-func FetchCloudigradeConfigs() (*CloudigradeConfig, error) {
-	resp, err := http.DefaultClient.Get("http://localhost:8000/api/cloudigrade/v2/sysconfig/")
+func FetchCloudigradeConfigs() error {
+	l.Log.Infof("Fetching cloudigrade sysconfig from [%v%v]", CLOUDIGRADE_URL, CLOUDIGRADE_SYSCONFIG_PATH)
+	resp, err := http.DefaultClient.Get(fmt.Sprintf("%v%v", CLOUDIGRADE_URL, CLOUDIGRADE_SYSCONFIG_PATH))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	sysconfig := CloudigradeSysConfig{}
 	err = json.Unmarshal(body, &sysconfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal cloudigrade sysconfig")
+		return fmt.Errorf("failed to unmarshal cloudigrade sysconfig")
 	}
 
 	azureTemplate, err := fetchAzureOfferTemplate(sysconfig.AzureOfferTemplatePath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	err = os.WriteFile(CLOUDIGRADE_AZURE_TEMPLATE_PATH, []byte(azureTemplate), 0644)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return &CloudigradeConfig{SysConfig: sysconfig, AzureTemplate: azureTemplate}, nil
+	CloudigradeConfig = &cloudigradeConfig{SysConfig: sysconfig, AzureTemplate: azureTemplate}
+	return nil
 }
 
 func fetchAzureOfferTemplate(path string) (string, error) {
-	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://localhost:8000%v", path))
+	l.Log.Infof("Fetching cloudigrade azure template from [%v%v]", CLOUDIGRADE_URL, path)
+	resp, err := http.DefaultClient.Get(fmt.Sprintf("%v%v", CLOUDIGRADE_URL, path))
 	if err != nil {
 		return "", err
 	}
@@ -73,4 +82,34 @@ func fetchAzureOfferTemplate(path string) (string, error) {
 	}
 
 	return string(body), nil
+}
+
+func CopyLocalAzureTemplate() error {
+	_, err := os.Stat(CLOUDIGRADE_AZURE_TEMPLATE_PATH)
+
+	// we are fine with the file not existing, but if it isn't that specific
+	// error, bubble up.
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	in, err := os.Open(CLOUDIGRADE_AZURE_TEMPLATE_LOCAL_PATH)
+	if err != nil {
+		return fmt.Errorf("failed to open default template (not mounted)")
+	}
+	defer in.Close()
+
+	out, err := os.Create(CLOUDIGRADE_AZURE_TEMPLATE_PATH)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file")
+	}
+	defer out.Close()
+
+	l.Log.Infof("Copying [%v] to [%v]", CLOUDIGRADE_AZURE_TEMPLATE_LOCAL_PATH, CLOUDIGRADE_AZURE_TEMPLATE_PATH)
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return fmt.Errorf("failed to copy template file")
+	}
+
+	return nil
 }

--- a/provider/cloudigrade_configs.go
+++ b/provider/cloudigrade_configs.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+var (
+	CLOUDIGRADE_AZURE_TEMPLATE_PATH = "/tmp/az_payload.json"
+	CLOUDIGRADE_AZURE_SECRET_PATH   = os.Getenv("AZURE_TEMPLATE_PATH")
+)
+
+var CloudigradeTemplateImported = false
+
+type CloudigradeConfig struct {
+	SysConfig     CloudigradeSysConfig
+	AzureTemplate string
+}
+
+type CloudigradeSysConfig struct {
+	AwsAccountID string `json:"aws_account_id"`
+	AwsPolicies  struct {
+		TraditionalInspection map[string]interface{}
+	} `json:"aws_policies"`
+	AzureOfferTemplatePath string `json:"azure_offer_template_path"`
+	Version                string `json:"version"`
+}
+
+func FetchCloudigradeConfigs() (*CloudigradeConfig, error) {
+	resp, err := http.DefaultClient.Get("http://localhost:8000/api/cloudigrade/v2/sysconfig/")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	sysconfig := CloudigradeSysConfig{}
+	err = json.Unmarshal(body, &sysconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cloudigrade sysconfig")
+	}
+
+	azureTemplate, err := fetchAzureOfferTemplate(sysconfig.AzureOfferTemplatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = os.WriteFile(CLOUDIGRADE_AZURE_TEMPLATE_PATH, []byte(azureTemplate), 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CloudigradeConfig{SysConfig: sysconfig, AzureTemplate: azureTemplate}, nil
+}
+
+func fetchAzureOfferTemplate(path string) (string, error) {
+	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://localhost:8000%v", path))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/provider/cloudigrade_configs.go
+++ b/provider/cloudigrade_configs.go
@@ -60,7 +60,7 @@ func FetchCloudigradeConfigs() error {
 		return err
 	}
 
-	err = os.WriteFile(CLOUDIGRADE_AZURE_TEMPLATE_PATH, []byte(azureTemplate), 0644)
+	err = ioutil.WriteFile(CLOUDIGRADE_AZURE_TEMPLATE_PATH, []byte(azureTemplate), 0644)
 	if err != nil {
 		return err
 	}

--- a/provider/forge.go
+++ b/provider/forge.go
@@ -57,7 +57,6 @@ func getProvider(request *superkey.CreateRequest) (superkey.Provider, error) {
 
 	switch request.Provider {
 	case "amazon":
-		// client, err := amazon.NewClient(os.Getenv("AWS_ACCESS"), os.Getenv("AWS_SECRET"), getStepNames(request.SuperKeySteps)...)
 		client, err := amazon.NewClient(
 			*auth.Username,
 			*auth.Password,
@@ -68,6 +67,9 @@ func getProvider(request *superkey.CreateRequest) (superkey.Provider, error) {
 		}
 
 		return &AmazonProvider{Client: client}, nil
+
+	case "azure":
+		return &AzureProvider{Username: *auth.Username, Password: *auth.Password}, nil
 	default:
 		return nil, fmt.Errorf("unsupported auth provider %v", request.Provider)
 	}

--- a/provider/helpers.go
+++ b/provider/helpers.go
@@ -1,0 +1,17 @@
+package provider
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// generateGUID() generates a short guid for resources
+func generateGUID() (string, error) {
+	bytes := make([]byte, 8)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(bytes), nil
+}

--- a/superkey/create_request.go
+++ b/superkey/create_request.go
@@ -19,7 +19,7 @@ func (req *CreateRequest) MarkSourceUnavailable(incomingErr error, newApplicatio
 	}
 
 	availabilityStatus := "unavailable"
-	availabilityStatusError := fmt.Sprintf("Resource Creation erorr: failed to create resources in amazon, error: %v", incomingErr)
+	availabilityStatusError := fmt.Sprintf("Resource Creation erorr: failed to create resources in %v, error: %v", newApplication.Request.Provider, incomingErr)
 	extra := make(map[string]interface{})
 
 	// creating the aws resources was at least partially successful, need to store

--- a/superkey/create_request.go
+++ b/superkey/create_request.go
@@ -18,8 +18,16 @@ func (req *CreateRequest) MarkSourceUnavailable(incomingErr error, newApplicatio
 		return err
 	}
 
+	// setting the provider name for the error message - since it can be nil potentially.
+	var provider string
+	if newApplication == nil || newApplication.Request == nil {
+		provider = "cloud provider"
+	} else {
+		provider = newApplication.Request.Provider
+	}
+
 	availabilityStatus := "unavailable"
-	availabilityStatusError := fmt.Sprintf("Resource Creation erorr: failed to create resources in %v, error: %v", newApplication.Request.Provider, incomingErr)
+	availabilityStatusError := fmt.Sprintf("Resource Creation erorr: failed to create resources in %v: %v", provider, incomingErr)
 	extra := make(map[string]interface{})
 
 	// creating the aws resources was at least partially successful, need to store


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-16681

This PR adds support for using the `az` cli tool to deploy lighthouse templates. 

Basically the provider leverages the same interface/patterns I already established for amazon but for azure. the `AzCli` struct contains the business logic of running the commands.

The basic flow is:
1. Get internal authentication, make sure user+pass+tenant are all present
2. Instantiate `AzureProvider` struct with user/pass/tenant, then call `Provider#ForgeApplication(CreateRequest)`
3. Forge then does 4 things:
4. a. Creates an instance of `AzCli` with a tempdir as its home directory
5. b. Runs `az login` (since it's using a tempdir as a homedir for the subprocess it is a clean slate every time)
6. c. Runs `az deployment sub create`, followed by `az deployment sub show --name=xxxx` to get the name of the subscription, checking the error part of the payload
7. d. Runs `az logout` and deletes the tempdir home directory so it is like nothing ever happened.
8. Return to sources on success/error - if success it posts the resources back and checks availability. Otherwise it just marks the app as unavailable with the error message. 

Either way this is kind of a big one. There will be a related [sources-api PR](https://github.com/RedHatInsights/sources-api/pull/457) with the new resources and support for returning this authtype.

Another thing this adds is a call out to the cloudigrade API sysconfig endpoint - fetching their template, but falling back to one if it's mounted in the filesystem as a secret. 