### PR TITLE
[RHCLOUD-18924] feature: use "latest" tag for the "ubi-minimal" image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,4 +41,4 @@ jobs:
           only-new-issues: true
           timeout: 2m
           skip-go-installation: true
-          args: --enable gci,bodyclose,forcetypeassert,misspell
+          args: --enable gci,bodyclose,forcetypeassert,misspell --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-218 as build
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as build
 WORKDIR /build
 
 RUN microdnf install go
 
 COPY go.mod .
-RUN go mod download 
+RUN go mod download
 
 COPY . .
 RUN go build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-218
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=build /build/sources-superkey-worker /sources-superkey-worker
 
 ENTRYPOINT ["/sources-superkey-worker"]


### PR DESCRIPTION
Time ago we were requested to use the "latest" tag from the security
team, so that the security updates would apply automatically on every
build.

This change makes us comply with that.

## Links

[[RHCLOUD-18924]](https://issues.redhat.com/browse/RHCLOUD-18924)