### PR TITLE
[RHCLOUD-19642] Bump sonarqube scanner versions

### DIFF
--- a/scripts/sonarqube.bash
+++ b/scripts/sonarqube.bash
@@ -54,7 +54,7 @@ else
   readonly sonar_scanner_os="linux"
 fi
 
-readonly sonar_scanner_cli_version="4.6.2.2472"
+readonly sonar_scanner_cli_version="4.7.0.2747"
 readonly sonar_scanner_name="sonar-scanner-$sonar_scanner_cli_version-$sonar_scanner_os"
 readonly sonar_scanner_zipped_file="$sonarqube_download_dir/$sonar_scanner_name.zip"
 

--- a/scripts/sonarqube.bash
+++ b/scripts/sonarqube.bash
@@ -58,7 +58,7 @@ readonly sonar_scanner_cli_version="4.7.0.2747"
 readonly sonar_scanner_name="sonar-scanner-$sonar_scanner_cli_version-$sonar_scanner_os"
 readonly sonar_scanner_zipped_file="$sonarqube_download_dir/$sonar_scanner_name.zip"
 
-curl --output "$sonar_scanner_zipped_file" --insecure "$SONARQUBE_CLI_URL"
+curl --output "$sonar_scanner_zipped_file" "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip"
 unzip -d "$sonarqube_extract_dir" "$sonar_scanner_zipped_file"
 
 #


### PR DESCRIPTION
This PR does two things:

1. Bumps the scanner's version to the latest one available.
2. Removes the scanner's download URL from the secret and puts it in the script itself, since we don't need to keep that URL a  secret.

## Links

[[RHCLOUD-19642]](https://issues.redhat.com/browse/RHCLOUD-19642)