### PR TITLE
[RHCLOUD-20566] feature: support for "OrgId" headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.3
-	github.com/redhatinsights/platform-go-middlewares v0.12.0
+	github.com/redhatinsights/platform-go-middlewares v0.19.0
 	github.com/segmentio/kafka-go v0.4.30
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1248,6 +1248,8 @@ github.com/redhatinsights/platform-go-middlewares v0.8.1/go.mod h1:koDaxx4Ht3ZgX
 github.com/redhatinsights/platform-go-middlewares v0.10.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/platform-go-middlewares v0.12.0 h1:gLFgsqupumRqAKDuYtvrYVNQr53iqfhQYc98VJ/cRUs=
 github.com/redhatinsights/platform-go-middlewares v0.12.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.19.0 h1:KEOVfDTOE0OpOKSb8HeEuYblFa2bpXvXpHRV/6706RM=
+github.com/redhatinsights/platform-go-middlewares v0.19.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68/go.mod h1:D74VLRhmYd+tGF1eid7+HLUKytgsm9L2dS9CoR+lxXM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/provider/forge.go
+++ b/provider/forge.go
@@ -44,7 +44,7 @@ func TearDown(f *superkey.ForgedApplication) []error {
 
 // getProvider returns a provider based on create request's provider + credentials
 func getProvider(request *superkey.CreateRequest) (superkey.Provider, error) {
-	client := sources.SourcesClient{AccountNumber: request.TenantID, IdentityHeader: request.IdentityHeader}
+	client := sources.SourcesClient{AccountNumber: request.TenantID, IdentityHeader: request.IdentityHeader, OrgId: request.OrgIdHeader}
 	auth, err := client.GetInternalAuthentication(request.SuperKey)
 	if err != nil {
 		l.Log.Errorf("Failed to get superkey credentials for %v, auth id %v", request.TenantID, request.SuperKey)

--- a/superkey/create_request.go
+++ b/superkey/create_request.go
@@ -22,7 +22,7 @@ func (req *CreateRequest) MarkSourceUnavailable(incomingErr error, newApplicatio
 	}
 
 	if newApplication.SourcesClient == nil {
-		newApplication.SourcesClient = &sources.SourcesClient{IdentityHeader: req.IdentityHeader, AccountNumber: req.TenantID}
+		newApplication.SourcesClient = &sources.SourcesClient{IdentityHeader: req.IdentityHeader, OrgId: req.OrgIdHeader, AccountNumber: req.TenantID}
 	}
 
 	l.Log.Infof("Marking Application %v Unavailable with message: %v", req.ApplicationID, availabilityStatusError)

--- a/superkey/forged_application.go
+++ b/superkey/forged_application.go
@@ -39,7 +39,7 @@ func (f *ForgedApplication) CreateInSourcesAPI() error {
 
 	// create a sources client for our identity + account number
 	if f.SourcesClient == nil {
-		f.SourcesClient = &sources.SourcesClient{IdentityHeader: f.Request.IdentityHeader, AccountNumber: f.Request.TenantID}
+		f.SourcesClient = &sources.SourcesClient{IdentityHeader: f.Request.IdentityHeader, OrgId: f.Request.OrgIdHeader, AccountNumber: f.Request.TenantID}
 	}
 
 	l.Log.Infof("Posting resources back to Sources API: %v", f)

--- a/superkey/types.go
+++ b/superkey/types.go
@@ -8,6 +8,7 @@ import (
 // CreateRequest - struct representing a request for a superkey
 type CreateRequest struct {
 	IdentityHeader  string            `json:"identity_header"`
+	OrgIdHeader     string            `json:"org_id_header"`
 	TenantID        string            `json:"tenant_id"`
 	SourceID        string            `json:"source_id"`
 	ApplicationID   string            `json:"application_id"`


### PR DESCRIPTION
Adds support for the "x-rh-sources-org-id" header, which is forwarded in the case that Superkey receives it first.

## Links

[[RHCLOUD-20566]](https://issues.redhat.com/browse/RHCLOUD-20566)