### PR TITLE
Fix null pointer when the app fails to even be created

### DIFF
--- a/superkey/create_request.go
+++ b/superkey/create_request.go
@@ -19,6 +19,10 @@ func (req *CreateRequest) MarkSourceUnavailable(incomingErr error, newApplicatio
 	// how far progress was made.
 	if newApplication != nil {
 		extra = newApplication.applicationExtraPayload()
+	} else {
+		// this can happen if the request fails _very early_ in the request
+		// process, e.g. if the superkey auth is unavailable.
+		newApplication = &ForgedApplication{}
 	}
 
 	if newApplication.SourcesClient == nil {


### PR DESCRIPTION
Had this in a stash and completely forgot about it until testing today where my sources-api was returning a 500 because my rbac was complaining! It's a very small edge case - but can happen if the request gets "fail"'d really early in the process, e.g. when fetching the superkey auth. 