### PR TITLE
Pull in new kafka changes from sources-api to prevent panicing on kafka errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhatinsights/sources-superkey-worker
 go 1.16
 
 require (
-	github.com/RedHatInsights/sources-api-go v0.0.0-20220728181510-29764130db2c
+	github.com/RedHatInsights/sources-api-go v0.0.0-20220818163754-607bade3247d
 	github.com/aws/aws-sdk-go v1.44.65
 	github.com/aws/aws-sdk-go-v2 v1.15.0
 	github.com/aws/aws-sdk-go-v2/config v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/RedHatInsights/rbac-client-go v1.0.0/go.mod h1:+7A7JULqhAnpSnWYXM4WsY
 github.com/RedHatInsights/sources-api-go v0.0.0-20211213144039-456336cb8e5c/go.mod h1:4C3CdPsFr5ZhdVa5coel1TkUgwWKwsqXgKQKiwy18bg=
 github.com/RedHatInsights/sources-api-go v0.0.0-20220728181510-29764130db2c h1:wOfIG4estgfLT0TX+zPlrxq5/ixzRaFBypJTen/PLcg=
 github.com/RedHatInsights/sources-api-go v0.0.0-20220728181510-29764130db2c/go.mod h1:0sO6AV5ZgtJBj+LUBd4VuBlJell9fPrYJDEWXWKOz+c=
+github.com/RedHatInsights/sources-api-go v0.0.0-20220818163754-607bade3247d h1:fSIw4Ytgyd9mkvEFZCMJV+r9o4cCk7p2iqLOy6hfNiU=
+github.com/RedHatInsights/sources-api-go v0.0.0-20220818163754-607bade3247d/go.mod h1:0sO6AV5ZgtJBj+LUBd4VuBlJell9fPrYJDEWXWKOz+c=
 github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f/go.mod h1:wgdbAAraizlXVvWfFd01uoaU+4dC3yaSaFxPzvvffG8=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/main.go
+++ b/main.go
@@ -39,7 +39,12 @@ func main() {
 	l.Log.Infof("Listening to Kafka at: %s:%d, topic: %v", conf.KafkaBrokerConfig.Hostname, conf.KafkaBrokerConfig.Port, superkeyTopic)
 	l.Log.Infof("Talking to Sources API at: [%v] using PSK [%v]", fmt.Sprintf("%v://%v:%v", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort), conf.SourcesPSK)
 
-	reader, err := kafka.GetReader(&conf.KafkaBrokerConfig, conf.KafkaGroupID, superkeyTopic)
+	reader, err := kafka.GetReader(&kafka.Options{
+		BrokerConfig: &conf.KafkaBrokerConfig,
+		Topic:        superkeyTopic,
+		GroupID:      &conf.KafkaGroupID,
+		Logger:       l.Log.WithField("kafka", ""),
+	})
 	if err != nil {
 		l.Log.Fatalf(`could not get Kafka reader: %s`, err)
 	}


### PR DESCRIPTION
This prevents panics whenever there is something wrong with kafka. For example if kafka isn't reachable:

Before: 
```
[ master ~m~ ] ~/cloud/git/crc/sources/superkey_worker 
$> make run
go build .
./sources-superkey-worker
Clowder is not enabled, skipping init...
{"@timestamp":"2022-08-18T12:35:43.015Z","@version":1,"app":"sources-superkey-worker","caller":"main.main","hostname":"mewtwo","labels":{"app":"sources-superkey-worker"},"level":"info","message":"Listening to Kafka at: mewtwo:824636583624, topic: platform.sources.superkey-requests","tags":["sources-superkey-worker"]}
{"@timestamp":"2022-08-18T12:35:43.015Z","@version":1,"app":"sources-superkey-worker","caller":"main.main","hostname":"mewtwo","labels":{"app":"sources-superkey-worker"},"level":"info","message":"Talking to Sources API at: [http://localhost:8000] using PSK []","tags":["sources-superkey-worker"]}
{"@timestamp":"2022-08-18T12:35:43.015Z","@version":1,"app":"sources-superkey-worker","caller":"main.main","hostname":"mewtwo","labels":{"app":"sources-superkey-worker"},"level":"info","message":"SuperKey Worker started.","tags":["sources-superkey-worker"]}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2c pc=0x72c7a6]

goroutine 1 [running]:
github.com/sirupsen/logrus.(*Logger).level(...)
        /home/jlindgren/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/logger.go:358
github.com/sirupsen/logrus.(*Logger).IsLevelEnabled(...)
        /home/jlindgren/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/logger.go:380
github.com/sirupsen/logrus.(*Logger).Logf(0x0, 0x3, 0x1613375, 0x2e, 0xc000123d38, 0x1, 0x1)
        /home/jlindgren/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/logger.go:152 +0x26
github.com/sirupsen/logrus.(*Logger).Warnf(...)
        /home/jlindgren/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/logger.go:178
github.com/RedHatInsights/sources-api-go/kafka.Consume(0xc0002c2000, 0x162eb68)
        /home/jlindgren/go/pkg/mod/github.com/!red!hat!insights/sources-api-go@v0.0.0-20220728181510-29764130db2c/kafka/kafka.go:34 +0x188
main.main()
        /home/jlindgren/cloud/git/crc/sources/superkey_worker/main.go:50 +0x47f
make: *** [Makefile:16: run] Error 2
```

After:
```
[ master ~m~ ] ~/cloud/git/crc/sources/superkey_worker 
$> make run
go build .
./sources-superkey-worker
Clowder is not enabled, skipping init...
{"@timestamp":"2022-08-18T12:35:36.17Z","@version":1,"app":"sources-superkey-worker","caller":"main.main","hostname":"mewtwo","labels":{"app":"sources-superkey-worker"},"level":"info","message":"Listening to Kafka at: mewtwo:824636739320, topic: platform.sources.superkey-requests","tags":["sources-superkey-worker"]}
{"@timestamp":"2022-08-18T12:35:36.17Z","@version":1,"app":"sources-superkey-worker","caller":"main.main","hostname":"mewtwo","labels":{"app":"sources-superkey-worker"},"level":"info","message":"Talking to Sources API at: [http://localhost:8000] using PSK []","tags":["sources-superkey-worker"]}
{"@timestamp":"2022-08-18T12:35:36.17Z","@version":1,"app":"sources-superkey-worker","caller":"main.main","hostname":"mewtwo","labels":{"app":"sources-superkey-worker"},"level":"info","message":"SuperKey Worker started.","tags":["sources-superkey-worker"]}
{"@timestamp":"2022-08-18T12:35:36.171Z","@version":1,"app":"sources-superkey-worker","caller":"github.com/segmentio/kafka-go.LoggerFunc.Printf","hostname":"mewtwo","kafka":"","labels":{"app":"sources-superkey-worker"},"level":"error","message":"Unable to establish connection to consumer group coordinator for group sources-superkey-worker: failed to dial: failed to open connection to mewtwo:9092: dial tcp 100.117.62.65:9092: connect: connection refused","tags":["sources-superkey-worker"]}
{"@timestamp":"2022-08-18T12:35:36.171Z","@version":1,"app":"sources-superkey-worker","caller":"github.com/segmentio/kafka-go.LoggerFunc.Printf","hostname":"mewtwo","kafka":"","labels":{"app":"sources-superkey-worker"},"level":"error","message":"failed to dial: failed to open connection to mewtwo:9092: dial tcp 100.117.62.65:9092: connect: connection refused","tags":["sources-superkey-worker"]}
^Cmake: *** [Makefile:16: run] Interrupt
```