### PR TITLE
Add support for Zinc Search Logging Hook

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -23,12 +23,6 @@ objects:
           value: ${DISABLE_RESOURCE_CREATION}
         - name: DISABLE_RESOURCE_DELETION
           value: ${DISABLE_RESOURCE_DELETION}
-        - name: HABERDASHER_EMITTER
-          value: ${HABERDASHER_EMITTER}
-        - name: HABERDASHER_KAFKA_BOOTSTRAP
-          value: ${HABERDASHER_KAFKA_BOOTSTRAP}
-        - name: HABERDASHER_KAFKA_TOPIC
-          value: ${HABERDASHER_KAFKA_TOPIC}
         - name: SOURCES_SCHEME
           value: ${SOURCES_SCHEME}
         - name: SOURCES_HOST
@@ -81,15 +75,6 @@ parameters:
 - description: Clowder ENV
   name: ENV_NAME
   required: true
-- description: Emitter for haberdasher logs [stderr|kafka]
-  name: HABERDASHER_EMITTER
-  value: stderr
-- description: Bootstrap server for haberdasher kafka emitter
-  name: HABERDASHER_KAFKA_BOOTSTRAP
-  value: ''
-- description: Kafka topic for haberdasher kafka emitter
-  name: HABERDASHER_KAFKA_TOPIC
-  value: ''
 - description: Image
   name: IMAGE
   value: quay.io/cloudservices/sources-superkey-worker

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.0
 	github.com/klauspost/compress v1.15.9 // indirect
+	github.com/lindgrenj6/logrus_zinc v0.0.0-20220822152658-d8a0b604f3f9
 	github.com/pelletier/go-toml/v2 v2.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RedHatInsights/rbac-client-go v1.0.0/go.mod h1:+7A7JULqhAnpSnWYXM4WsYol3tEoCR8AVeob0Qby3Zc=
 github.com/RedHatInsights/sources-api-go v0.0.0-20211213144039-456336cb8e5c/go.mod h1:4C3CdPsFr5ZhdVa5coel1TkUgwWKwsqXgKQKiwy18bg=
-github.com/RedHatInsights/sources-api-go v0.0.0-20220728181510-29764130db2c h1:wOfIG4estgfLT0TX+zPlrxq5/ixzRaFBypJTen/PLcg=
-github.com/RedHatInsights/sources-api-go v0.0.0-20220728181510-29764130db2c/go.mod h1:0sO6AV5ZgtJBj+LUBd4VuBlJell9fPrYJDEWXWKOz+c=
 github.com/RedHatInsights/sources-api-go v0.0.0-20220818163754-607bade3247d h1:fSIw4Ytgyd9mkvEFZCMJV+r9o4cCk7p2iqLOy6hfNiU=
 github.com/RedHatInsights/sources-api-go v0.0.0-20220818163754-607bade3247d/go.mod h1:0sO6AV5ZgtJBj+LUBd4VuBlJell9fPrYJDEWXWKOz+c=
 github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f/go.mod h1:wgdbAAraizlXVvWfFd01uoaU+4dC3yaSaFxPzvvffG8=
@@ -959,6 +957,8 @@ github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
+github.com/lindgrenj6/logrus_zinc v0.0.0-20220822152658-d8a0b604f3f9 h1:1ZOLHrWXURL/KtmTmp5uGvZYltM1Wyjl+leEc2AIqOs=
+github.com/lindgrenj6/logrus_zinc v0.0.0-20220822152658-d8a0b604f3f9/go.mod h1:HXJquze/kJdqYytVKMHUWi0xedbcliBESUuNsJPJY7I=
 github.com/lindgrenj6/sources-api-client-go v0.0.0-20210215174124-caba6974c015/go.mod h1:/YFovfrDZPDRqtBJuTbMGwL5VbP8umAzBFS6cqhfOw4=
 github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/lindgrenj6/logrus_zinc"
 	lc "github.com/redhatinsights/platform-go-middlewares/logging/cloudwatch"
 	appconf "github.com/redhatinsights/sources-superkey-worker/config"
 	"github.com/sirupsen/logrus"
@@ -125,6 +126,11 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 			Log.Info(err)
 		}
 		Log.Hooks.Add(hook)
+	}
+
+	// add a zinc search hook if we're set up for it
+	if zinc, err := logrus_zinc.FromEnv(); err != nil {
+		Log.Hooks.Add(zinc)
 	}
 
 	return Log

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -78,10 +78,6 @@ func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func forwardLogsToStderr(logHandler string) bool {
-	return logHandler == "haberdasher"
-}
-
 // InitLogger initializes the Sources SuperKey logger
 func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 	logconfig := viper.New()
@@ -110,14 +106,8 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 
 	formatter := NewCustomLoggerFormatter()
 
-	logOutput := os.Stdout
-
-	if forwardLogsToStderr(cfg.LogHandler) {
-		logOutput = os.Stderr
-	}
-
 	Log = &logrus.Logger{
-		Out:          logOutput,
+		Out:          os.Stdout,
 		Level:        logLevel,
 		Formatter:    formatter,
 		Hooks:        make(logrus.LevelHooks),
@@ -127,7 +117,7 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 	// TODO: maybe redo this to work with the go-aws-v2 library.
 	// That would involve updating the platform middleware though, which might
 	// not be fun.
-	if key != "" && secret != "" && !forwardLogsToStderr(cfg.LogHandler) {
+	if key != "" && secret != "" {
 		cred := credentials.NewStaticCredentials(key, secret, "")
 		awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 		hook, err := lc.NewBatchingHook(group, stream, awsconf, 10*time.Second)


### PR DESCRIPTION
1. Removed Haberdasher flags/checks since it is no more
2. Added a check for Zinc Search environment varialbes and send logs there if set up properly. 

Just set these environment variables when running your application:

<table>
<tr>
	<td>Variable
	<td>Description
<tr>
	<td>`ZINC_SEARCH_URL`
	<td>URL where zinc lives, e.g. `http://localhost:4080` which it defaults to
<tr>
	<td>`ZINC_SEARCH_INDEX`
	<td>Which Index to store logs under, defaults to `default`
<tr>
	<td>`ZINC_SEARCH_USERNAME`
	<td>Username for basic auth, set during podman run command
<tr>
	<td>`ZINC_SEARCH_PASSWORD`
	<td>Password for basic auth, set during podman run command
</table>