### PR TITLE
Fail gracefully when cloudwatch fails to be set up

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -123,7 +123,7 @@ func InitLogger(cfg *appconf.SuperKeyWorkerConfig) *logrus.Logger {
 		awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 		hook, err := lc.NewBatchingHook(group, stream, awsconf, 10*time.Second)
 		if err != nil {
-			Log.Info(err)
+			Log.Fatal(err)
 		}
 		Log.Hooks.Add(hook)
 	}


### PR DESCRIPTION
Currently getting a panic due to a nil pointer on stage when the cloudwatch logs are failing to get set up, I would like to fail if cloudwatch fails still but instead of a stacktrace lets just print the error and exit. 