### PR TITLE
Fix Makefile to use 'go run .' rather than hackily filtering out testfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ container:
 run: build
 	./sources-superkey-worker
 
+inlinerun:
+	go run .
+
 fancyrun: build
 	./sources-superkey-worker | grep '^{' | jq -r .
 


### PR DESCRIPTION
In the same vein as https://github.com/RedHatInsights/sources-api-go/pull/623