### PR TITLE
[RHCLOUD-29368] added KubeLinter check 'run-as-non-root' in the Sources Superkey Worker deployment

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -13,6 +13,8 @@ objects:
     - name: svc
       minReplicas: ${{MIN_REPLICAS}}
       podSpec:
+        securityContext:
+          runAsNonRoot: true
         image: ${IMAGE}:${IMAGE_TAG}
         env:
         - name: LOG_LEVEL


### PR DESCRIPTION
the `deployment_validation_operator_run_as_non_root` is failing ([dashboard](https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=crcp01ue1&var-namespace=sources-prod)) so this PR adds the security context to solve this requirement

JIRA: [RHCLOUD-29368](https://issues.redhat.com/browse/RHCLOUD-29368)