### PR TITLE
[RHCLOUD-29368] added runAsUser param into securityContext

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -15,6 +15,7 @@ objects:
       podSpec:
         securityContext:
           runAsNonRoot: true
+          runAsUser: 1000
         image: ${IMAGE}:${IMAGE_TAG}
         env:
         - name: LOG_LEVEL


### PR DESCRIPTION
JIRA: [RHCLOUD-29368](https://issues.redhat.com/browse/RHCLOUD-29368)

docs: https://docs.kubelinter.io/#/generated/checks?id=run-as-non-root