### PR TITLE
[RHCLOUD-32289] updated values for memory limit and request for sources superkey worker

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -70,9 +70,9 @@ objects:
       replicas: 3
 parameters:
 - name: CPU_LIMIT
-  value: "100m"
-- name: CPU_REQUEST
   value: "50m"
+- name: CPU_REQUEST
+  value: "20m"
 - name: DISABLE_RESOURCE_CREATION
   value: "false"
 - name: DISABLE_RESOURCE_DELETION
@@ -92,9 +92,9 @@ parameters:
 - name: CONTAINER_LOG_LEVEL
   value: INFO
 - name: MEMORY_LIMIT
-  value: "50Mi"
+  value: "100Mi"
 - name: MEMORY_REQUEST
-  value: "25Mi"
+  value: "50Mi"
 - name: MIN_REPLICAS
   description: The number of replicas to use for the prometheus deployment
   value: "1"


### PR DESCRIPTION
JIRA [RHCLOUD-32289](https://issues.redhat.com/browse/RHCLOUD-32289)

update cpu/memory values for limit and request to be more aligned with long term data
https://grafana.stage.devshift.net/d/HXbU7G1Iz/aandm-resources-health?orgId=1&from=now-30d&to=now&var-Datasource=crcp01ue1-prometheus
![image](https://github.com/RedHatInsights/sources-superkey-worker/assets/89980168/b8f07cbd-58d6-4215-ad4b-67aa9ba1ebce)

![image](https://github.com/RedHatInsights/sources-superkey-worker/assets/89980168/7bff26b3-115a-4179-b062-be29bb925b43)


note: the value for memory limit is set in [app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/sources/deploy-clowder.yml#L132) too, so after we deploy this change on prod environment the value in app-interface will be removed