### PR TITLE
[RHCLOUD-32453] use the latest ubi9/ubi-minimal in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as build
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as build
 WORKDIR /build
 
-RUN microdnf install go
+RUN microdnf -y install go
 
 COPY go.mod .
 RUN go mod download
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 RUN go build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=build /build/sources-superkey-worker /sources-superkey-worker
 
 ENTRYPOINT ["/sources-superkey-worker"]


### PR DESCRIPTION
Jira [RHCLOUD-32453](https://issues.redhat.com/browse/RHCLOUD-32453)

use the ubi9 images to solve the vulnerability in ubi8
```
quay.io/cloudservices/sources-superkey-worker:4eb3eab
NAME    INSTALLED         FIXED-IN            TYPE  VULNERABILITY   SEVERITY
gnutls  3.6.16-8.el8_9.1  0:3.6.16-8.el8_9.3  rpm   CVE-2024-28834  Medium
```

with ubi9 (tested locally)
```
$ podman build -t sources-superkey-worker:v1 .
...
$ grype --only-fixed localhost/sources-superkey-worker:v1
...
No vulnerabilities found
```