### PR TITLE
[RHCLOUD-32453] Revert "use the latest ubi9/ubi-minimal in Dockerfile"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as build
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as build
 WORKDIR /build
 
-RUN microdnf -y install go
+RUN microdnf install go
 
 COPY go.mod .
 RUN go mod download
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 RUN go build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=build /build/sources-superkey-worker /sources-superkey-worker
 
 ENTRYPOINT ["/sources-superkey-worker"]


### PR DESCRIPTION
This reverts commit 0a1505c1950c8a8344b8550295e2c18e920df6aa
https://github.com/RedHatInsights/sources-superkey-worker/pull/83
[RHCLOUD-32453](https://issues.redhat.com/browse/RHCLOUD-32453)
we cannot use ubi9 because the ubi8 is only one base image approved by our federal customers