### PR TITLE
[RHCLOUD-33770] update github actions (checkout, setup-go, golangci-lint-action, gofmt-action) to the latest version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,20 +9,20 @@ jobs:
     name: go fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.17"
-      - uses: Jerome1337/gofmt-action@v1.0.4
+          go-version: "1.18"
+      - uses: Jerome1337/gofmt-action@v1.0.5
 
   govet:
     name: go vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - run: |
           go vet ./...
 
@@ -30,14 +30,13 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           only-new-issues: true
-          skip-go-installation: true
           args: --enable gci,bodyclose,forcetypeassert,misspell --timeout=5m


### PR DESCRIPTION
[RHCLOUD-33770](https://issues.redhat.com/browse/RHCLOUD-33770)

bump github actions to the latest versions
- [checkout](https://github.com/actions/checkout)
- [setup-go](https://github.com/actions/setup-go)
- [golangci-lint-action](https://github.com/golangci/golangci-lint-action)
- [gofmt-action](https://github.com/Jerome1337/gofmt-action)

and change the GO version to the 1.18 because it is [version we use here](https://github.com/RedHatInsights/sources-superkey-worker/blob/b2a8c5cdfda213835464ce22a0cbc03ae844e0aa/go.mod#L3)