### PR TITLE
RHCLOUD-36959 | feature: improve logging for the Superkey worker

### DIFF
--- a/amazon/s3.go
+++ b/amazon/s3.go
@@ -2,7 +2,6 @@ package amazon
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
@@ -28,7 +27,7 @@ func (a *Client) DestroyS3Bucket(name string) error {
 		Bucket: &name,
 	})
 	if err != nil {
-		return fmt.Errorf("error during s3 bucket deletion during cleanup: %v", err)
+		return err
 	}
 
 	for _, object := range objects.Contents {
@@ -37,7 +36,7 @@ func (a *Client) DestroyS3Bucket(name string) error {
 			Key:    object.Key,
 		})
 		if err != nil {
-			return fmt.Errorf("error during s3 bucket deletion during cleanup: %v", err)
+			return err
 		}
 	}
 
@@ -45,7 +44,7 @@ func (a *Client) DestroyS3Bucket(name string) error {
 		Bucket: &name,
 	})
 	if err != nil {
-		return fmt.Errorf("error during s3 bucket deletion: %v", err)
+		return err
 	}
 
 	return nil

--- a/amazon/types.go
+++ b/amazon/types.go
@@ -1,6 +1,8 @@
 package amazon
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cost "github.com/aws/aws-sdk-go-v2/service/costandusagereportservice"
 	costtypes "github.com/aws/aws-sdk-go-v2/service/costandusagereportservice/types"
@@ -47,7 +49,7 @@ type Client struct {
 
 // NewClient - takes a key+secret and list of API clients to set up
 // returns: new AmazonClient and error
-func NewClient(key, sec string, apis ...string) (*Client, error) {
+func NewClient(ctx context.Context, key, sec string, apis ...string) (*Client, error) {
 	a := Client{AccessKey: key, SecretKey: sec}
 
 	creds, err := NewAmazonConfig(key, sec)
@@ -72,7 +74,7 @@ func NewClient(key, sec string, apis ...string) (*Client, error) {
 				a.CostReporting = cost.NewFromConfig(*creds)
 			}
 		default:
-			l.Log.Errorf(`Unsupported "%s" API requested when creating an Amazon client`, api)
+			l.LogWithContext(ctx).Errorf(`Unsupported "%s" API requested when creating an Amazon client`, api)
 		}
 
 	}

--- a/amazon/types.go
+++ b/amazon/types.go
@@ -72,7 +72,7 @@ func NewClient(key, sec string, apis ...string) (*Client, error) {
 				a.CostReporting = cost.NewFromConfig(*creds)
 			}
 		default:
-			l.Log.Warnf("Unused api: %v", api)
+			l.Log.Errorf(`Unsupported "%s" API requested when creating an Amazon client`, api)
 		}
 
 	}

--- a/logger/logger_context.go
+++ b/logger/logger_context.go
@@ -1,0 +1,79 @@
+package logger
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+// tenantIdCtxKeyType defines the type for the tenant's key that will ensure type safety when storing or fetching the
+// variable to/from the context.
+type tenantIdCtxKeyType string
+
+// sourceIdCtxKeyType defines the type for the source's key that will ensure type safety when storing or fetching the
+// variable to/from the context.
+type sourceIdCtxKeyType string
+
+// applicationIdCtxKeyType defines the type for the application's key that will ensure type safety when storing or
+// fetching the variable to/from the context.
+type applicationIdCtxKeyType string
+
+// applicationTypeCtxKeyType defines the type for the application type's key that will ensure type safety when storing
+// or fetching the variable to/from the context.
+type applicationTypeCtxKeyType string
+
+// tenantIdCtxKey defines the key to be used to store the tenant's identifier.
+const tenantIdCtxKey tenantIdCtxKeyType = "tenant_id"
+
+// sourceIdCtxKey defines the key to be used to store the source's identifier.
+const sourceIdCtxKey sourceIdCtxKeyType = "source_id"
+
+// applicationIdCtxKey defines the key to be used to store the application's identifier.
+const applicationIdCtxKey applicationIdCtxKeyType = "application_id"
+
+// applicationTypeCtxKey defines the key to be used to store the application type's identifier.
+const applicationTypeCtxKey applicationTypeCtxKeyType = "application_type"
+
+// LogWithContext returns a logger with all the fields defined in the context.
+func LogWithContext(ctx context.Context) *logrus.Entry {
+	logFields := logrus.Fields{}
+
+	if tenantId, ok := ctx.Value(tenantIdCtxKey).(tenantIdCtxKeyType); ok {
+		logFields["tenant_id"] = tenantId
+	}
+
+	if sourceId, ok := ctx.Value(sourceIdCtxKey).(sourceIdCtxKeyType); ok {
+		logFields["source_id"] = sourceId
+	}
+
+	if applicationId, ok := ctx.Value(applicationIdCtxKey).(applicationIdCtxKeyType); ok {
+		logFields["application_id"] = applicationId
+	}
+
+	if applicationType, ok := ctx.Value(applicationTypeCtxKey).(applicationTypeCtxKeyType); ok {
+		logFields["application_type"] = applicationType
+	}
+
+	return Log.WithFields(logFields)
+}
+
+// WithTenantId creates a new context by copying the given context and appending the tenant's identifier to it.
+func WithTenantId(ctx context.Context, tenantId string) context.Context {
+	return context.WithValue(ctx, tenantIdCtxKey, tenantId)
+}
+
+// WithSourceId creates a new context by copying the given context and appending the source's identifier to it.
+func WithSourceId(ctx context.Context, sourceId string) context.Context {
+	return context.WithValue(ctx, sourceIdCtxKey, sourceId)
+}
+
+// WithApplicationId creates a new context by copying the given context and appending the application's identifier to
+// it.
+func WithApplicationId(ctx context.Context, applicationId string) context.Context {
+	return context.WithValue(ctx, applicationIdCtxKey, applicationId)
+}
+
+// WithApplicationType creates a new context by copying the given context and appending the application's type to it.
+func WithApplicationType(ctx context.Context, applicationType string) context.Context {
+	return context.WithValue(ctx, applicationTypeCtxKey, applicationType)
+}

--- a/provider/forge.go
+++ b/provider/forge.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/redhatinsights/sources-superkey-worker/amazon"
-	l "github.com/redhatinsights/sources-superkey-worker/logger"
 	"github.com/redhatinsights/sources-superkey-worker/sources"
 	"github.com/redhatinsights/sources-superkey-worker/superkey"
 )
@@ -13,8 +12,9 @@ import (
 func Forge(request *superkey.CreateRequest) (*superkey.ForgedApplication, error) {
 	client, err := getProvider(request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get provider: %w", err)
 	}
+
 	f, err := client.ForgeApplication(request)
 
 	// returning both every time. we need the state of the forged product to know what to
@@ -45,27 +45,25 @@ func TearDown(f *superkey.ForgedApplication) []error {
 // getProvider returns a provider based on create request's provider + credentials
 func getProvider(request *superkey.CreateRequest) (superkey.Provider, error) {
 	client := sources.SourcesClient{AccountNumber: request.TenantID, IdentityHeader: request.IdentityHeader, OrgId: request.OrgIdHeader}
-	auth, err := client.GetInternalAuthentication(request.SuperKey)
+	auth, err := client.GetInternalAuthentication(request.TenantID, request.SourceID, request.SuperKey)
 	if err != nil {
-		l.Log.Errorf("Failed to get superkey credentials for %v, auth id %v", request.TenantID, request.SuperKey)
-		return nil, err
+		return nil, fmt.Errorf(`error while fetching internal authentication "%s" from Sources: %w`, request.SuperKey, err)
 	}
 
 	if auth.Username == "" || auth.Password == "" {
-		l.Log.Errorf("superkey credential %v missing username or password", request.SuperKey)
-		return nil, fmt.Errorf("superkey credential %v missing username or password", request.SuperKey)
+		return nil, fmt.Errorf(`missing username or password from authentication ID "%s" and superkey credential "%s"`, auth.ID, request.SuperKey)
 	}
 
 	switch request.Provider {
 	case "amazon":
 		client, err := amazon.NewClient(auth.Username, auth.Password, getStepNames(request.SuperKeySteps)...)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf(`unable to create Amazon client with authentication ID "%s": %w`, auth.ID, err)
 		}
 
 		return &AmazonProvider{Client: client}, nil
 	default:
-		return nil, fmt.Errorf("unsupported auth provider %v", request.Provider)
+		return nil, fmt.Errorf(`unsupported auth provider "%s"`, request.Provider)
 	}
 }
 

--- a/superkey/types.go
+++ b/superkey/types.go
@@ -1,6 +1,8 @@
 package superkey
 
 import (
+	"context"
+
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/redhatinsights/sources-superkey-worker/sources"
 )
@@ -60,6 +62,6 @@ type ForgedApplication struct {
 // Provider the interface for all of the superkey providers currently just a
 // single method is needed (ForgeApplication)
 type Provider interface {
-	ForgeApplication(*CreateRequest) (*ForgedApplication, error)
-	TearDown(*ForgedApplication) []error
+	ForgeApplication(ctx context.Context, createRequest *CreateRequest) (*ForgedApplication, error)
+	TearDown(ctx context.Context, forgedApplication *ForgedApplication) []error
 }


### PR DESCRIPTION
Many of the current logs provided way too much information which made monitoring the service really hard. The goal of these changes is to provide that extra information only when an error occurs or when the "debug" log level is enabled.

For the rest of the informational logs, we are fine with just following the status of the worker.

## Jira ticket
[[RHCLOUD-36959]](https://issues.redhat.com/browse/RHCLOUD-36959)