### PR TITLE
RHCLOUD-35843 | refactor: Sources' REST API client

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,21 +11,22 @@ import (
 
 // SuperKeyWorkerConfig is the struct for storing runtime configuration
 type SuperKeyWorkerConfig struct {
-	Hostname           string
-	KafkaBrokerConfig  []clowder.BrokerConfig
-	KafkaTopics        map[string]string
-	KafkaGroupID       string
-	MetricsPort        int
-	LogLevel           string
-	LogGroup           string
-	LogHandler         string
-	AwsRegion          string
-	AwsAccessKeyID     string
-	AwsSecretAccessKey string
-	SourcesHost        string
-	SourcesScheme      string
-	SourcesPort        int
-	SourcesPSK         string
+	Hostname                   string
+	KafkaBrokerConfig          []clowder.BrokerConfig
+	KafkaTopics                map[string]string
+	KafkaGroupID               string
+	MetricsPort                int
+	LogLevel                   string
+	LogGroup                   string
+	LogHandler                 string
+	AwsRegion                  string
+	AwsAccessKeyID             string
+	AwsSecretAccessKey         string
+	SourcesHost                string
+	SourcesScheme              string
+	SourcesPort                int
+	SourcesPSK                 string
+	SourcesRequestsMaxAttempts int
 }
 
 // Get - returns the config parsed from runtime vars
@@ -81,6 +82,20 @@ func Get() *SuperKeyWorkerConfig {
 	options.SetDefault("SourcesPort", os.Getenv("SOURCES_PORT"))
 	options.SetDefault("SourcesPSK", os.Getenv("SOURCES_PSK"))
 
+	// Get the number of maximum request attempts we want to make to the Sources' API.
+	sourcesRequestsMaxAttempts, err := strconv.Atoi(os.Getenv("SOURCES_REQUEST_MAX_ATTEMPTS"))
+	if err != nil {
+		log.Printf(`Warning: the provided max attempts value \"%s\" is not an integer. Setting default value of 3.`, os.Getenv("SOURCES_REQUEST_MAX_ATTEMPTS"))
+		sourcesRequestsMaxAttempts = 3
+	}
+
+	if sourcesRequestsMaxAttempts < 1 {
+		log.Printf(`Warning: the provided max attempts value \"%s\" is lower than 1, and we need to at least make one attempt when calling Sources. Setting default value of 3.`, os.Getenv("SOURCES_REQUEST_MAX_ATTEMPTS"))
+		sourcesRequestsMaxAttempts = 3
+	}
+
+	options.SetDefault("SourcesRequestsMaxAttempts", sourcesRequestsMaxAttempts)
+
 	hostname, _ := os.Hostname()
 	options.SetDefault("Hostname", hostname)
 
@@ -94,21 +109,22 @@ func Get() *SuperKeyWorkerConfig {
 	options.AutomaticEnv()
 
 	return &SuperKeyWorkerConfig{
-		Hostname:           options.GetString("Hostname"),
-		KafkaBrokerConfig:  brokerConfig,
-		KafkaTopics:        options.GetStringMapString("KafkaTopics"),
-		KafkaGroupID:       options.GetString("KafkaGroupID"),
-		MetricsPort:        options.GetInt("MetricsPort"),
-		LogLevel:           options.GetString("LogLevel"),
-		LogHandler:         options.GetString("LogHandler"),
-		LogGroup:           options.GetString("LogGroup"),
-		AwsRegion:          options.GetString("AwsRegion"),
-		AwsAccessKeyID:     options.GetString("AwsAccessKeyID"),
-		AwsSecretAccessKey: options.GetString("AwsSecretAccessKey"),
-		SourcesHost:        options.GetString("SourcesHost"),
-		SourcesScheme:      options.GetString("SourcesScheme"),
-		SourcesPort:        options.GetInt("SourcesPort"),
-		SourcesPSK:         options.GetString("SourcesPSK"),
+		Hostname:                   options.GetString("Hostname"),
+		KafkaBrokerConfig:          brokerConfig,
+		KafkaTopics:                options.GetStringMapString("KafkaTopics"),
+		KafkaGroupID:               options.GetString("KafkaGroupID"),
+		MetricsPort:                options.GetInt("MetricsPort"),
+		LogLevel:                   options.GetString("LogLevel"),
+		LogHandler:                 options.GetString("LogHandler"),
+		LogGroup:                   options.GetString("LogGroup"),
+		AwsRegion:                  options.GetString("AwsRegion"),
+		AwsAccessKeyID:             options.GetString("AwsAccessKeyID"),
+		AwsSecretAccessKey:         options.GetString("AwsSecretAccessKey"),
+		SourcesHost:                options.GetString("SourcesHost"),
+		SourcesScheme:              options.GetString("SourcesScheme"),
+		SourcesPort:                options.GetInt("SourcesPort"),
+		SourcesPSK:                 options.GetString("SourcesPSK"),
+		SourcesRequestsMaxAttempts: options.GetInt("SourcesRequestsMaxAttempts"),
 	}
 }
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -114,3 +114,6 @@ parameters:
   displayName: AWS Wait Time
   description: Time to sleep between creating the resources and posting back to Sources API
   value: "15"
+- name: SOURCES_REQUEST_MAX_ATTEMPTS
+  description: The maximum request attempts to make when calling the Sources API.
+  value: "3"

--- a/logger/logger_context.go
+++ b/logger/logger_context.go
@@ -2,6 +2,8 @@ package logger
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 
 	"github.com/sirupsen/logrus"
 )
@@ -22,6 +24,30 @@ type applicationIdCtxKeyType string
 // or fetching the variable to/from the context.
 type applicationTypeCtxKeyType string
 
+// authenticationIdCtxKeyType defines the type for the authentication's identifier key that will ensure type safety
+// when storing or fetching the variable to/from the context.
+type authenticationIdCtxKeyType string
+
+// resourceTypeCtxKeyType defines the type for the resource's type key that will ensure type safety when storing or
+// fetching the variable to/from the context.
+type resourceTypeCtxKeyType string
+
+// resourceIdCtxKeyType defines the type for the resource's identifier key that will ensure type safety when storing or
+// fetching the variable to/from the context.
+type resourceIdCtxKeyType string
+
+// httpMethodCtxKeyType defines the type for the HTTP method key that will ensure type safety when storing or
+// fetching the variable to/from the context.
+type httpMethodCtxKeyType string
+
+// urlCtxKeyType defines the type for the URL key that will ensure type safety when storing or fetching the variable
+// to/from the context.
+type urlCtxKeyType string
+
+// urlCtxKeyType defines the type for the HTTP headers key that will ensure type safety when storing or fetching the
+// variable to/from the context.
+type httpHeadersCtxKeyType string
+
 // tenantIdCtxKey defines the key to be used to store the tenant's identifier.
 const tenantIdCtxKey tenantIdCtxKeyType = "tenant_id"
 
@@ -33,6 +59,24 @@ const applicationIdCtxKey applicationIdCtxKeyType = "application_id"
 
 // applicationTypeCtxKey defines the key to be used to store the application type's identifier.
 const applicationTypeCtxKey applicationTypeCtxKeyType = "application_type"
+
+// authenticationIdCtxKey defines the key to be used to store the authentication's identifier.
+const authenticationIdCtxKey authenticationIdCtxKeyType = "authentication_id"
+
+// resourceTypeCtxKey defines the key to be used to store the resource's type.
+const resourceTypeCtxKey resourceTypeCtxKeyType = "resource_type"
+
+// resourceIdCtxKey defines the key to be used to store the resource's identifier.
+const resourceIdCtxKey resourceIdCtxKeyType = "resource_id"
+
+// httpMethodCtxKey defines the key to be used to store the HTTP method's identifier.
+const httpMethodCtxKey httpMethodCtxKeyType = "http_method"
+
+// urlCtxKey defines the key to be used to store the URL's identifier.
+const urlCtxKey urlCtxKeyType = "url"
+
+// httpHeadersCtxKey defines the key to be used to store the HTTP headers' identifier.
+const httpHeadersCtxKey httpHeadersCtxKeyType = "http_headers"
 
 // LogWithContext returns a logger with all the fields defined in the context.
 func LogWithContext(ctx context.Context) *logrus.Entry {
@@ -52,6 +96,30 @@ func LogWithContext(ctx context.Context) *logrus.Entry {
 
 	if applicationType, ok := ctx.Value(applicationTypeCtxKey).(applicationTypeCtxKeyType); ok {
 		logFields["application_type"] = applicationType
+	}
+
+	if authenticationId, ok := ctx.Value(authenticationIdCtxKey).(authenticationIdCtxKeyType); ok {
+		logFields["authentication_id"] = authenticationId
+	}
+
+	if resourceType, ok := ctx.Value(resourceTypeCtxKey).(resourceTypeCtxKeyType); ok {
+		logFields["resource_type"] = resourceType
+	}
+
+	if resourceId, ok := ctx.Value(resourceIdCtxKey).(resourceIdCtxKeyType); ok {
+		logFields["resource_id"] = resourceId
+	}
+
+	if httpMethod, ok := ctx.Value(httpMethodCtxKey).(authenticationIdCtxKeyType); ok {
+		logFields["http_method"] = httpMethod
+	}
+
+	if urlVar, ok := ctx.Value(urlCtxKey).(urlCtxKeyType); ok {
+		logFields["url"] = urlVar
+	}
+
+	if httpHeaders, ok := ctx.Value(httpHeadersCtxKey).(httpHeadersCtxKeyType); ok {
+		logFields["http_headers"] = httpHeaders
 	}
 
 	return Log.WithFields(logFields)
@@ -76,4 +144,35 @@ func WithApplicationId(ctx context.Context, applicationId string) context.Contex
 // WithApplicationType creates a new context by copying the given context and appending the application's type to it.
 func WithApplicationType(ctx context.Context, applicationType string) context.Context {
 	return context.WithValue(ctx, applicationTypeCtxKey, applicationType)
+}
+
+// WithAuthenticationId creates a new context by copying the given context and appending the authentication's
+// identifier to it.
+func WithAuthenticationId(ctx context.Context, authenticationId string) context.Context {
+	return context.WithValue(ctx, authenticationIdCtxKey, authenticationId)
+}
+
+// WithResourceType creates a new context by copying the given context and appending the resource's type to it.
+func WithResourceType(ctx context.Context, resourceType string) context.Context {
+	return context.WithValue(ctx, resourceTypeCtxKey, resourceType)
+}
+
+// WithResourceId creates a new context by copying the given context and appending the resource's identifier to it.
+func WithResourceId(ctx context.Context, resourceId string) context.Context {
+	return context.WithValue(ctx, resourceIdCtxKey, resourceId)
+}
+
+// WithHttpMethod creates a new context by copying the given context and appending the HTTP method to it.
+func WithHttpMethod(ctx context.Context, httpMethod string) context.Context {
+	return context.WithValue(ctx, httpMethodCtxKey, httpMethod)
+}
+
+// WithURL creates a new context by copying the given context and appending the URL to it.
+func WithURL(ctx context.Context, url *url.URL) context.Context {
+	return context.WithValue(ctx, urlCtxKey, url.String())
+}
+
+// WithHTTPHeaders creates a new context by copying the given context and appending the HTTP headers to it.
+func WithHTTPHeaders(ctx context.Context, headers http.Header) context.Context {
+	return context.WithValue(ctx, httpHeadersCtxKey, headers)
 }

--- a/provider/forge.go
+++ b/provider/forge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/redhatinsights/sources-superkey-worker/amazon"
+	"github.com/redhatinsights/sources-superkey-worker/config"
 	"github.com/redhatinsights/sources-superkey-worker/sources"
 	"github.com/redhatinsights/sources-superkey-worker/superkey"
 )
@@ -45,8 +46,14 @@ func TearDown(ctx context.Context, f *superkey.ForgedApplication) []error {
 
 // getProvider returns a provider based on create request's provider + credentials
 func getProvider(ctx context.Context, request *superkey.CreateRequest) (superkey.Provider, error) {
-	client := sources.SourcesClient{AccountNumber: request.TenantID, IdentityHeader: request.IdentityHeader, OrgId: request.OrgIdHeader}
-	auth, err := client.GetInternalAuthentication(ctx, request.SuperKey)
+	sourcesRestClient := sources.NewSourcesClient(config.Get())
+
+	authData := sources.AuthenticationData{
+		IdentityHeader: request.IdentityHeader,
+		OrgId:          request.OrgIdHeader,
+	}
+
+	auth, err := sourcesRestClient.GetInternalAuthentication(ctx, &authData, request.SuperKey)
 	if err != nil {
 		return nil, fmt.Errorf(`error while fetching internal authentication "%s" from Sources: %w`, request.SuperKey, err)
 	}

--- a/sources/api_client.go
+++ b/sources/api_client.go
@@ -8,277 +8,259 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/redhatinsights/sources-superkey-worker/config"
 	l "github.com/redhatinsights/sources-superkey-worker/logger"
-	"github.com/sirupsen/logrus"
 )
 
-var conf = config.Get()
+// sourcesClient holds the required information to be able to send requests back to the Sources API.
+type sourcesClient struct {
+	baseV31URL         *url.URL
+	baseV20InternalUrl *url.URL
+	config             *config.SuperKeyWorkerConfig
+}
 
-type SourcesClient struct {
+// AuthenticationData holds the required authentication elements that need to be sent back to the Sources API when
+// making a request.
+type AuthenticationData struct {
 	IdentityHeader string
 	OrgId          string
 	AccountNumber  string
 }
 
-func (sc *SourcesClient) CheckAvailability(ctx context.Context, sourceId string) error {
-	reqURL, _ := url.Parse(fmt.Sprintf(
-		"%v://%v:%v/api/sources/v3.1/sources/%v/check_availability", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort, sourceId,
-	))
+// PatchApplicationRequest represents the fields that we might want to update when updating the application's details.
+//
+// The AvailabilityStatus field represents the current application's availability status.
+// The AvailabilityStatusError field gives information about why the status might not be "available".
+// The Extra field allows adding extra fields to the application, such as the Superkey key.
+type PatchApplicationRequest struct {
+	AvailabilityStatus      *string                `json:"availability_status"`
+	AvailabilityStatusError *string                `json:"availability_status_error"`
+	Extra                   map[string]interface{} `json:"extra"`
+}
 
-	req := &http.Request{
-		Method: http.MethodPost,
-		URL:    reqURL,
-		Header: sc.headers(),
+// PatchSourceRequest represents the availability status field that we might want to update in a Source.
+//
+// The AvailabilityStatus field represents the current sources' availability status.
+type PatchSourceRequest struct {
+	AvailabilityStatus *string `json:"availability_status"`
+}
+
+// NewSourcesClient initializes a new SourcesClient to be able to communicate with the Sources API.
+func NewSourcesClient(config *config.SuperKeyWorkerConfig) *sourcesClient {
+	return &sourcesClient{
+		baseV20InternalUrl: &url.URL{
+			Host:   fmt.Sprintf("%s:%d", config.SourcesHost, config.SourcesPort),
+			Path:   "/internal/v2.0/",
+			Scheme: config.SourcesScheme,
+		},
+		baseV31URL: &url.URL{
+			Host:   fmt.Sprintf("%s:%d", config.SourcesHost, config.SourcesPort),
+			Path:   "/api/sources/v3.1",
+			Scheme: config.SourcesScheme,
+		},
+		config: config,
 	}
+}
 
-	resp, err := http.DefaultClient.Do(req)
+func (sc *sourcesClient) TriggerSourceAvailabilityCheck(ctx context.Context, authData *AuthenticationData, sourceId string) error {
+	checkAvailabilityUrl := sc.baseV31URL.JoinPath("/sources/", url.PathEscape(sourceId), "/check_availability")
+
+	// Set the logging fields.
+	ctx = l.WithSourceId(ctx, sourceId)
+
+	return sc.sendRequest(ctx, http.MethodPost, checkAvailabilityUrl, authData, nil, nil)
+}
+
+func (sc *sourcesClient) CreateAuthentication(ctx context.Context, authData *AuthenticationData, sourcesAuthentication *model.AuthenticationCreateRequest) (*model.AuthenticationResponse, error) {
+	createAuthenticationUrl := sc.baseV31URL.JoinPath("/authentications")
+
+	// Set the logging fields.
+	ctx = l.WithResourceType(ctx, sourcesAuthentication.ResourceType)
+	ctx = l.WithResourceId(ctx, strconv.FormatInt(sourcesAuthentication.ResourceID, 10))
+
+	var createdAuthentication model.AuthenticationResponse
+	err := sc.sendRequest(ctx, http.MethodPost, createAuthenticationUrl, authData, sourcesAuthentication, createdAuthentication)
 	if err != nil {
-		return fmt.Errorf("unable to send request: %w", err)
+		return nil, fmt.Errorf("error while creating authentication: %w", err)
 	}
 
-	l.LogWithContext(ctx).WithField("request_url", reqURL).Debugf("Requesting an availability check")
+	return &createdAuthentication, nil
+}
 
-	defer resp.Body.Close()
+func (sc *sourcesClient) CreateApplicationAuthentication(ctx context.Context, authData *AuthenticationData, appAuthCreateRequest *model.ApplicationAuthenticationCreateRequest) error {
+	createApplicationAuthenticationUrl := sc.baseV31URL.JoinPath("/application_authentications")
 
-	if resp.StatusCode != 202 {
-		return fmt.Errorf(`expecting a 202 status code, got "%d"`, resp.StatusCode)
+	// Set the logging fields.
+	ctx = l.WithApplicationId(ctx, strconv.FormatInt(appAuthCreateRequest.ApplicationID, 10))
+	ctx = l.WithAuthenticationId(ctx, strconv.FormatInt(appAuthCreateRequest.AuthenticationID, 10))
+
+	err := sc.sendRequest(ctx, http.MethodPost, createApplicationAuthenticationUrl, authData, appAuthCreateRequest, nil)
+	if err != nil {
+		return fmt.Errorf("error while creating the application authentication: %w", err)
 	}
 
 	return nil
 }
 
-func (sc *SourcesClient) CreateAuthentication(ctx context.Context, auth *model.AuthenticationCreateRequest) error {
-	reqURL, _ := url.Parse(fmt.Sprintf(
-		"%v://%v:%v/api/sources/v3.1/authentications", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort,
-	))
+func (sc *sourcesClient) PatchApplication(ctx context.Context, authData *AuthenticationData, appId string, patchApplicationRequest *PatchApplicationRequest) error {
+	patchApplicationUrl := sc.baseV31URL.JoinPath("/applications/", url.PathEscape(appId))
 
-	body, err := json.Marshal(auth)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request body: %w", err)
-	}
+	// Set the logging fields.
+	ctx = l.WithApplicationId(ctx, appId)
 
-	l.LogWithContext(ctx).WithFields(logrus.Fields{"request_url": reqURL, "body": string(body)}).Debugf("Creating authentication in Sources")
-
-	req := &http.Request{
-		Method: http.MethodPost,
-		URL:    reqURL,
-		Header: sc.headers(),
-		Body:   io.NopCloser(bytes.NewBuffer(body)),
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("unable to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(`expecting a 200 status code, got "%d" with body "%s"`, resp.StatusCode, string(b))
-	}
-
-	bytes, _ := io.ReadAll(resp.Body)
-	var createdAuth model.AuthenticationResponse
-	err = json.Unmarshal(bytes, &createdAuth)
-	if err != nil {
-		return fmt.Errorf("unable to unmarshal authentication creation response from Sources: %w", err)
-	}
-
-	err = sc.createApplicationAuthentication(ctx, &model.ApplicationAuthenticationCreateRequest{
-		ApplicationIDRaw:    auth.ResourceIDRaw,
-		AuthenticationIDRaw: createdAuth.ID,
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return sc.sendRequest(ctx, http.MethodPatch, patchApplicationUrl, authData, patchApplicationRequest, nil)
 }
 
-func (sc *SourcesClient) PatchApplication(ctx context.Context, appID string, payload map[string]interface{}) error {
-	reqURL, _ := url.Parse(fmt.Sprintf(
-		"%v://%v:%v/api/sources/v3.1/applications/%v", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort, appID,
-	))
+func (sc *sourcesClient) PatchSource(ctx context.Context, authData *AuthenticationData, sourceId string, patchSourceRequest *PatchSourceRequest) error {
+	patchSourceUrl := sc.baseV31URL.JoinPath("/sources/" + url.PathEscape(sourceId))
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request body: %w", err)
-	}
+	// Set the logging fields.
+	ctx = l.WithSourceId(ctx, sourceId)
 
-	l.LogWithContext(ctx).WithFields(logrus.Fields{"request_url": reqURL, "body": string(body)}).Debugf("Patching application in Sources")
-
-	req := &http.Request{
-		Method: http.MethodPatch,
-		URL:    reqURL,
-		Header: sc.headers(),
-		Body:   io.NopCloser(bytes.NewBuffer(body)),
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("unable to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(`expecting a 200 status code, got "%d" with body "%s"`, resp.StatusCode, string(b))
-	}
-
-	return nil
+	return sc.sendRequest(ctx, http.MethodPatch, patchSourceUrl, authData, patchSourceRequest, nil)
 }
 
-func (sc *SourcesClient) PatchSource(ctx context.Context, sourceId string, payload map[string]interface{}) error {
-	reqURL, _ := url.Parse(fmt.Sprintf(
-		"%v://%v:%v/api/sources/v3.1/sources/%v", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort, sourceId,
-	))
+func (sc *sourcesClient) GetInternalAuthentication(ctx context.Context, authData *AuthenticationData, authId string) (*model.AuthenticationInternalResponse, error) {
+	getInternalAuthUrl := sc.baseV20InternalUrl.JoinPath("/authentications/", url.PathEscape(authId), "/?expose_encrypted_attribute[]=password")
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
+	// Set the logging fields.
+	ctx = l.WithAuthenticationId(ctx, authId)
 
-	req := &http.Request{
-		Method: http.MethodPatch,
-		URL:    reqURL,
-		Header: sc.headers(),
-		Body:   io.NopCloser(bytes.NewBuffer(body)),
-	}
+	var authInternalResponse *model.AuthenticationInternalResponse = nil
+	err := sc.sendRequest(ctx, http.MethodGet, getInternalAuthUrl, authData, nil, &authInternalResponse)
 
-	l.LogWithContext(ctx).WithFields(logrus.Fields{"request_url": reqURL, "body": string(body)}).Debugf("Patching source in Sources")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("unable to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(`expecting a 200 status code, got "%d" with body "%s"`, resp.StatusCode, string(b))
-	}
-
-	return nil
+	return authInternalResponse, err
 }
 
-// GetInternalAuthentication requests an authentication via the internal sources api
-// that way we can expose the password.
-// returns: populated sources api Authentication object, error
-func (sc *SourcesClient) GetInternalAuthentication(ctx context.Context, authID string) (*model.AuthenticationInternalResponse, error) {
-	reqURL, _ := url.Parse(fmt.Sprintf(
-		"%v://%v:%v/internal/v2.0/authentications/%v?expose_encrypted_attribute[]=password", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort, authID,
-	))
+// sendRequest sends a request with the provided method and body to the given url, performing a maximum number of
+// attempts and marshaling the incoming response's body. You can leave the body and the marshalTarget arguments empty
+// if you do not require them.
+func (sc *sourcesClient) sendRequest(ctx context.Context, httpMethod string, url *url.URL, authData *AuthenticationData, body interface{}, marshalTarget interface{}) error {
+	// Set up a timeout so that the requests don't hang up forever.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 
-	req := &http.Request{
-		Method: http.MethodGet,
-		URL:    reqURL,
-		Header: sc.headers(),
+	// When a body is specified, attempt to marshal it as JSON.
+	var requestBody *bytes.Buffer = nil
+	if body != nil {
+		tmp, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+
+		requestBody = bytes.NewBuffer(tmp)
 	}
 
-	var res *http.Response
-	var err error
-	for retry := 0; retry < 5; retry++ {
-		l.LogWithContext(ctx).WithFields(logrus.Fields{"request_url": reqURL, "authentication_id": authID}).Debugf("Getting internal authentication from Sources")
+	// Create the request.
+	request, err := http.NewRequestWithContext(ctx, httpMethod, url.String(), requestBody)
+	if err != nil {
+		return fmt.Errorf(`failed to create request: %w`, err)
+	}
 
-		res, err = http.DefaultClient.Do(req)
+	// Include the headers in the request.
+	sc.addAuthenticationHeaders(request, authData)
 
-		if err != nil || res.StatusCode == 200 {
-			defer res.Body.Close()
+	// Add the logging fields to the context.
+	ctx = l.WithHttpMethod(ctx, httpMethod)
+	ctx = l.WithURL(ctx, url)
+	ctx = l.WithHTTPHeaders(ctx, request.Header)
+
+	// Perform the actual request.
+	var response *http.Response
+	for attempt := 0; attempt < sc.config.SourcesRequestsMaxAttempts; attempt++ {
+		response, err = http.DefaultClient.Do(request)
+
+		// The "err" check is to avoid nil dereference errors, since if we attempt checking for the status code
+		// directly when an error has occurred, the "response" struct might be nil.
+		if err == nil && sc.isStatusCodeFamilyOf2xx(response.StatusCode) {
 			break
-		} else {
-			l.LogWithContext(ctx).WithField("authentication_id", authID).Warn("Unable to fetch internal authentication. Retrying...")
-			time.Sleep(3 * time.Second)
+		}
+
+		// When there are no errors but the status code is not the expected one, we attempt to drain the body so that
+		// the default client can reuse the connection, and then we close the body to avoid memory leaks.
+		if err == nil && !sc.isStatusCodeFamilyOf2xx(response.StatusCode) {
+			_, drainErr := io.Copy(io.Discard, response.Body)
+
+			if drainErr != nil {
+				l.LogWithContext(ctx).Warnf("Unable to drain response body. The connection will not be reused by the default HTTP client: %s", drainErr)
+			}
+
+			if closeErr := response.Body.Close(); closeErr != nil {
+				l.LogWithContext(ctx).Errorf("Failed to close incoming response's body: %s", closeErr)
+			}
+
+			l.LogWithContext(ctx).Debugf(`Unexpected status code received. Want "2xx", got "%d"`, response.StatusCode)
+			continue
+		}
+
+		if err != nil {
+			l.LogWithContext(ctx).Warn("Failed to send request. Retrying...")
+			l.LogWithContext(ctx).Debugf("Failed to send request. Retrying... Cause: %s", err)
 		}
 	}
 
-	if err != nil || res.StatusCode != 200 {
-		return nil, fmt.Errorf(`unable to fetch internal authentication "%s" after 5 retries: %w`, authID, err)
+	// In the case in which we deplete all the attempts, we have to return the error and stop the execution here.
+	if err != nil || response == nil {
+		return fmt.Errorf("failed to send request: %w", err)
 	}
 
-	data, _ := io.ReadAll(res.Body)
-	auth := model.AuthenticationInternalResponse{}
-
-	// unmarshaling the data from the request, the id comes back as a string which fills `err`
-	// we can safely ignore that as long as username/pass are there.
-	err = json.Unmarshal(data, &auth)
-	if err != nil && (auth.Username == "" || auth.Password == "") {
-		return nil, fmt.Errorf(`internal authentication "%s"'s username or password are empty'`, authID)
+	// Always read the response body, in case we need to return it in an error or marshal it to a struct.
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf(`failed to read response body: %w`, err)
 	}
 
-	return &auth, nil
+	// Make sure that the status code is a "2xx" one.
+	if !sc.isStatusCodeFamilyOf2xx(response.StatusCode) {
+		return fmt.Errorf(`unexpected status code received. Want "2xx", got "%d". Response body: %s`, response.StatusCode, string(responseBody))
+	}
+
+	// We might need to marshal the incoming response in the specified struct.
+	if marshalTarget != nil {
+		err = json.Unmarshal(responseBody, &marshalTarget)
+		if err != nil {
+			return fmt.Errorf(`failed to unmarshal response body: %w`, err)
+		}
+	}
+
+	return nil
 }
 
-func (sc *SourcesClient) headers() map[string][]string {
-	var headers = make(map[string][]string)
+// isStatusCodeFamilyOf2xx returns true if the given status code is a 2xx status code.
+func (sc *sourcesClient) isStatusCodeFamilyOf2xx(statusCode int) bool {
+	return statusCode >= 200 && statusCode < 300
+}
 
-	headers["Content-Type"] = []string{"application/json"}
+func (sc *sourcesClient) addAuthenticationHeaders(request *http.Request, authData *AuthenticationData) {
+	request.Header.Add("Content-Type", "application/json")
 
-	if conf.SourcesPSK == "" {
+	if sc.config.SourcesPSK == "" {
 		var xRhId string
 
-		if sc.IdentityHeader == "" {
-			xRhId = encodeIdentity(sc.AccountNumber, sc.OrgId)
+		if authData.IdentityHeader == "" {
+			xRhId = encodeIdentity(authData.AccountNumber, authData.OrgId)
 		} else {
-			xRhId = sc.IdentityHeader
+			xRhId = authData.IdentityHeader
 		}
 
-		headers["x-rh-identity"] = []string{xRhId}
+		request.Header.Add("x-rh-identity", xRhId)
 	} else {
-		headers["x-rh-sources-psk"] = []string{conf.SourcesPSK}
+		request.Header.Add("x-rh-sources-psk", sc.config.SourcesPSK)
 
-		if sc.AccountNumber != "" {
-			headers["x-rh-sources-account-number"] = []string{sc.AccountNumber}
+		if authData.AccountNumber != "" {
+			request.Header.Add("x-rh-sources-account-number", authData.AccountNumber)
 		}
 
-		if sc.IdentityHeader != "" {
-			headers["x-rh-identity"] = []string{sc.IdentityHeader}
+		if authData.IdentityHeader != "" {
+			request.Header.Add("x-rh-identity", authData.IdentityHeader)
 		}
 
-		if sc.OrgId != "" {
-			headers["x-rh-org-id"] = []string{sc.OrgId}
+		if authData.OrgId != "" {
+			request.Header.Add("x-rh-org-id", authData.OrgId)
 		}
 	}
-
-	return headers
-}
-
-func (sc *SourcesClient) createApplicationAuthentication(ctx context.Context, appAuth *model.ApplicationAuthenticationCreateRequest) error {
-	reqURL, _ := url.Parse(fmt.Sprintf(
-		"%v://%v:%v/api/sources/v3.1/application_authentications", conf.SourcesScheme, conf.SourcesHost, conf.SourcesPort,
-	))
-
-	body, err := json.Marshal(appAuth)
-	if err != nil {
-		return err
-	}
-
-	req := &http.Request{
-		Method: http.MethodPost,
-		URL:    reqURL,
-		Header: sc.headers(),
-		Body:   io.NopCloser(bytes.NewBuffer(body)),
-	}
-
-	l.LogWithContext(ctx).WithFields(logrus.Fields{"request_url": reqURL, "body": string(body)}).Debugf("Creating application authentication in Sources")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("unable to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(`expecting a 200 status code, got "%d" with body "%s"`, resp.StatusCode, string(b))
-	}
-
-	return nil
 }

--- a/sources/api_client_interface.go
+++ b/sources/api_client_interface.go
@@ -1,0 +1,24 @@
+package sources
+
+import (
+	"context"
+
+	"github.com/RedHatInsights/sources-api-go/model"
+)
+
+// RestClient represents the Sources' endpoints that are required for the Superkey to be able to talk to the Sources'
+// API.
+type RestClient interface {
+	// TriggerSourceAvailabilityCheck triggers an availability status check in the Sources API for the given source.
+	TriggerSourceAvailabilityCheck(ctx context.Context, authData *AuthenticationData, sourceId string) error
+	// CreateAuthentication creates an authentication in Sources.
+	CreateAuthentication(ctx context.Context, authData *AuthenticationData, sourcesAuthentication *model.AuthenticationCreateRequest) (*model.AuthenticationResponse, error)
+	// CreateApplicationAuthentication links the created authentication with an application in Sources.
+	CreateApplicationAuthentication(ctx context.Context, authData *AuthenticationData, appAuthCreateRequest *model.ApplicationAuthenticationCreateRequest) error
+	// PatchApplication modifies an application in Sources.
+	PatchApplication(ctx context.Context, authData *AuthenticationData, appId string, patchApplicationRequest *PatchApplicationRequest) error
+	// PatchSource modifies an application in Sources.
+	PatchSource(ctx context.Context, authData *AuthenticationData, sourceId string, patchSourceRequest *PatchSourceRequest) error
+	// GetInternalAuthentication fetches an authentication using the internal Sources' endpoint, which ensure that the authentication will have the password as well.
+	GetInternalAuthentication(ctx context.Context, authData *AuthenticationData, authId string) (*model.AuthenticationInternalResponse, error)
+}

--- a/superkey/types.go
+++ b/superkey/types.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/RedHatInsights/sources-api-go/model"
-	"github.com/redhatinsights/sources-superkey-worker/sources"
 )
 
 // CreateRequest - struct representing a request for a superkey
@@ -56,7 +55,6 @@ type ForgedApplication struct {
 	Request        *CreateRequest
 	Client         Provider
 	GUID           string
-	SourcesClient  *sources.SourcesClient
 }
 
 // Provider the interface for all of the superkey providers currently just a


### PR DESCRIPTION
The REST API functions that were being used were almost a copy paste of
one another, which made following the code difficult.

The goal of the refactor was to simplify the code and make it easier to
follow and reason about. Also, it introduces a timeout for the requests
by default, which could be the cause for which the Superkey struggles so
much and ends up restarting non-stop.

Another goal of this refactor was to leave everything in an state where
it is easier to reason about how the Superkey worker should be
refactored further, like introducing proper dependency injection and
untangling the resource making from the "ForgeApplication" struct.
However, that's for another PR.

## Dependency
- https://github.com/RedHatInsights/sources-superkey-worker/pull/101

## Jira ticket
 [[RHCLOUD-35843]](https://issues.redhat.com/browse/RHCLOUD-35843)