### PR TITLE
RHCLOUD-36959 | fix: the API client panics sometimes with an empty body

### DIFF
--- a/sources/api_client.go
+++ b/sources/api_client.go
@@ -155,8 +155,16 @@ func (sc *sourcesClient) sendRequest(ctx context.Context, httpMethod string, url
 		requestBody = bytes.NewBuffer(tmp)
 	}
 
-	// Create the request.
-	request, err := http.NewRequestWithContext(ctx, httpMethod, url.String(), requestBody)
+	// Create the request. Apparently a nil "*bytes.Buffer" counts as a body, which in turn makes the code panic when
+	// creating a new request. That is why we add another "if" statement to guard us against that.
+	var request *http.Request
+	var err error
+	if requestBody != nil {
+		request, err = http.NewRequestWithContext(ctx, httpMethod, url.String(), requestBody)
+	} else {
+		request, err = http.NewRequestWithContext(ctx, httpMethod, url.String(), nil)
+	}
+
 	if err != nil {
 		return fmt.Errorf(`failed to create request: %w`, err)
 	}


### PR DESCRIPTION
Apparently a declared and nil buffer still counts as a body for the requests package, which caused panics locally. The issue was that the requests package was trying to read the buffer anyway.

## Jira ticket
[[RHCLOUD-36959]](https://issues.redhat.com/browse/RHCLOUD-36959)