### PR TITLE
fix: missing Clowdapp variable

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -40,6 +40,8 @@ objects:
               name: internal-psk
               key: psk
               optional: true
+        - name: SOURCES_REQUEST_MAX_ATTEMPTS
+          value: ${SOURCES_REQUEST_MAX_ATTEMPTS}
         - name: LOG_HANDLER
           value: ${LOG_HANDLER}
         - name: AWS_WAIT_TIME


### PR DESCRIPTION
The variable is missing from the Clowdapp template.