### PR TITLE
RHCLOUD-36959 | fix: API Client is unable to contact Sources

### DIFF
--- a/logger/logger_context.go
+++ b/logger/logger_context.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"context"
 	"net/http"
-	"net/url"
 
 	"github.com/sirupsen/logrus"
 )
@@ -168,8 +167,8 @@ func WithHttpMethod(ctx context.Context, httpMethod string) context.Context {
 }
 
 // WithURL creates a new context by copying the given context and appending the URL to it.
-func WithURL(ctx context.Context, url *url.URL) context.Context {
-	return context.WithValue(ctx, urlCtxKey, url.String())
+func WithURL(ctx context.Context, url string) context.Context {
+	return context.WithValue(ctx, urlCtxKey, url)
 }
 
 // WithHTTPHeaders creates a new context by copying the given context and appending the HTTP headers to it.


### PR DESCRIPTION
Apparently the "URL.String()" method escapes the special characters from the paths by default, which makes the calls to fetch internal authentications to fail, because the URL contains brackets.

Also, we were attempting to read the body after it was closed in the retry attempts, which was causing errors too. By moving it to the retries loop we fulfill two purposes:

1. Draining the body completely for a new retry and connection reuse.
2. Reading the body to be able to be used in log statements or to be marshalled.

## Jira ticket
[[RHCLOUD-36959]](https://issues.redhat.com/browse/RHCLOUD-36959)