### PR TITLE
RHCLOUD-39380 | fix: SonarQube's pipeline

### DIFF
--- a/scripts/scanner/scan_code.bash
+++ b/scripts/scanner/scan_code.bash
@@ -5,31 +5,52 @@
 #   - e is for exiting immediately when a command exits with a non-zero status.
 #   - u is for treating unset variables as an error when substituting.
 #   - x is for printing all the commands as they're executed.
-#   - o pipefail is for taking into account the exit status of the commands that run on pipelines.
+#   - o pipefail is for taking into account the exit status of the commands
+#     that run on pipelines.
 #
 set -euxo pipefail
 
 #
-# Copy the repository contents so we don't have to deal with changing permissions on the mounted volume.
+# Copy the repository contents so we don't have to deal with changing
+# permissions on the mounted volume.
 #
 source_dir=$(mktemp --directory)
+readonly source_dir
+
 cp --recursive "/repository" "${source_dir}"
 
 #
 # Run the sonar scanner.
 #
-
-sonar-scanner \
-  -Dsonar.exclusions="**/*.sql" \
-  -Dsonar.projectBaseDir="${source_dir}/repository" \
-  -Dsonar.projectKey="${SONAR_PROJECT_KEY}" \
-  -Dsonar.projectVersion="${SONAR_PROJECT_VERSION}" \
-  -Dsonar.pullrequest.base="main" \
-  -Dsonar.pullrequest.branch="${SONAR_PULL_REQUEST_BRANCH}" \
-  -Dsonar.pullrequest.key="${SONAR_PULL_REQUEST_KEY}" \
-  -Dsonar.sources="${source_dir}/repository"
+#
+# On the main branch there is no need to give the pull request details.
+#
+if [ -n "${GIT_BRANCH:-}" ] && { [ "${GIT_BRANCH}" == "main" ] || [ "${GIT_BRANCH}" == "origin/main" ]; }; then
+  sonar-scanner \
+    -Dsonar.exclusions="**/*.sql" \
+    -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
+    -Dsonar.projectBaseDir="${source_dir}/repository" \
+    -Dsonar.projectKey="${SONARQUBE_PROJECT_KEY}" \
+    -Dsonar.projectVersion="${COMMIT_SHORT}" \
+    -Dsonar.sourceEncoding="UTF-8" \
+    -Dsonar.sources="${source_dir}/repository" \
+    -Dsonar.token="${SONARQUBE_TOKEN}"
+else
+  sonar-scanner \
+    -Dsonar.exclusions="**/*.sql" \
+    -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
+    -Dsonar.projectBaseDir="${source_dir}/repository" \
+    -Dsonar.projectKey="${SONARQUBE_PROJECT_KEY}" \
+    -Dsonar.projectVersion="${COMMIT_SHORT}" \
+    -Dsonar.pullrequest.base="main" \
+    -Dsonar.pullrequest.branch="${GIT_BRANCH}" \
+    -Dsonar.pullrequest.key="${GITHUB_PULL_REQUEST_ID}" \
+    -Dsonar.sourceEncoding="UTF-8" \
+    -Dsonar.sources="${source_dir}/repository" \
+    -Dsonar.token="${SONARQUBE_TOKEN}"
+fi
 
 #
-# Clean the repository directory.
+# Clean the directory of the repository.
 #
 rm --force --recursive "${source_dir}"

--- a/scripts/sonarqube.bash
+++ b/scripts/sonarqube.bash
@@ -5,7 +5,8 @@
 #   - e is for exiting immediately when a command exits with a non-zero status.
 #   - u is for treating unset variables as an error when substituting.
 #   - x is for printing all the commands as they're executed.
-#   - o pipefail is for taking into account the exit status of the commands that run on pipelines.
+#   - o pipefail is for taking into account the exit status of the commands
+#     that run on pipelines.
 #
 set -euxo pipefail
 
@@ -13,30 +14,57 @@ set -euxo pipefail
 # Get the commit SHA to give the scanner a unique "project version" setting.
 #
 commit_short=$(git rev-parse --short=7 HEAD)
+readonly commit_short
 
 #
 # Get the current directory since it represents the project's root directory.
 #
 current_directory=$(pwd)
+readonly current_directory
 
 #
-# Run the Sonar Scanner in a container. The "repository" directory is just the source code, and we mount it to be able
-# to scan the source code.
+# Set the project's key.
 #
-docker run  \
-  --rm \
-  --volume "${current_directory}":/repository \
-  --env SONAR_LOGIN="${SONARQUBE_TOKEN}" \
-  --env SONAR_HOST_URL="${SONARQUBE_REPORT_URL}" \
-  --env SONAR_PROJECT_KEY="console.redhat.com:sources-superkey-worker" \
-  --env SONAR_PROJECT_VERSION="${commit_short}" \
-  --env SONAR_PULL_REQUEST_BASE="main" \
-  --env SONAR_PULL_REQUEST_BRANCH="${GIT_BRANCH}" \
-  --env SONAR_PULL_REQUEST_KEY="${ghprbPullId}" \
-  images.paas.redhat.com/alm/sonar-scanner:latest \
-  bash /repository/scripts/scanner/scan_code.bash
+project_key="sources-superkey-worker"
+readonly project_key
 
-# Need to make a dummy results file to make tests pass.
+#
+# Run the Sonar Scanner in a container. The "repository" directory is just the
+# source code, and we mount it to be able to scan the source code.
+#
+# Should we be running on main, then skip passing the information regarding the
+# pull request.
+#
+# Finally, the volume is mounted with the "z" option, because it seems like
+# the runner has SELinux activated, and that we need to relabel the directory
+# to have permission to read it. More information here: https://www.reddit.com/r/podman/comments/fww87v/permission_denied_within_mounted_volume_inside/
+#
+if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "origin/main" ]; then
+  podman run \
+    --env COMMIT_SHORT="${commit_short}" \
+    --env GIT_BRANCH="${GIT_BRANCH}" \
+    --env SONARQUBE_HOST_URL="${SONARQUBE_HOST_URL}" \
+    --env SONARQUBE_PROJECT_KEY="${project_key}" \
+    --env SONARQUBE_TOKEN="${SONARQUBE_TOKEN}" \
+    --rm \
+    --volume "${current_directory}":/repository:z \
+    images.paas.redhat.com/alm/sonar-scanner:latest \
+    bash /repository/scripts/scanner/scan_code.bash
+else
+  podman run \
+    --env COMMIT_SHORT="${commit_short}" \
+    --env GIT_BRANCH="${GIT_BRANCH}" \
+    --env GITHUB_PULL_REQUEST_ID="${ghprbPullId}" \
+    --env SONARQUBE_HOST_URL="${SONARQUBE_HOST_URL}" \
+    --env SONARQUBE_PROJECT_KEY="${project_key}" \
+    --env SONARQUBE_TOKEN="${SONARQUBE_TOKEN}" \
+    --rm \
+    --volume "${current_directory}":/repository:z \
+    images.paas.redhat.com/alm/sonar-scanner:latest \
+    bash /repository/scripts/scanner/scan_code.bash
+fi
+
+# We need to make a dummy results file to make tests pass.
 mkdir -p artifacts
 cat << EOF > artifacts/junit-dummy.xml
 <testsuite tests="1">


### PR DESCRIPTION
The SonarQube scans were failing because the runner that runs them had some SELinux permission issues, which forced us to have to relabel the mounted volume in order to be able to read it.

## Jira ticket
[[RHCLOUD-39380]](https://issues.redhat.com/browse/RHCLOUD-39380)