### PR TITLE
fix: SonarQube uses "main" instead of "master" to compare the code

### DIFF
--- a/scripts/scanner/scan_code.bash
+++ b/scripts/scanner/scan_code.bash
@@ -23,9 +23,9 @@ cp --recursive "/repository" "${source_dir}"
 # Run the sonar scanner.
 #
 #
-# On the main branch there is no need to give the pull request details.
+# On the master branch there is no need to give the pull request details.
 #
-if [ -n "${GIT_BRANCH:-}" ] && { [ "${GIT_BRANCH}" == "main" ] || [ "${GIT_BRANCH}" == "origin/main" ]; }; then
+if [ -n "${GIT_BRANCH:-}" ] && { [ "${GIT_BRANCH}" == "master" ] || [ "${GIT_BRANCH}" == "origin/master" ]; }; then
   sonar-scanner \
     -Dsonar.exclusions="**/*.sql" \
     -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
@@ -42,7 +42,7 @@ else
     -Dsonar.projectBaseDir="${source_dir}/repository" \
     -Dsonar.projectKey="${SONARQUBE_PROJECT_KEY}" \
     -Dsonar.projectVersion="${COMMIT_SHORT}" \
-    -Dsonar.pullrequest.base="main" \
+    -Dsonar.pullrequest.base="master" \
     -Dsonar.pullrequest.branch="${GIT_BRANCH}" \
     -Dsonar.pullrequest.key="${GITHUB_PULL_REQUEST_ID}" \
     -Dsonar.sourceEncoding="UTF-8" \

--- a/scripts/sonarqube.bash
+++ b/scripts/sonarqube.bash
@@ -32,14 +32,14 @@ readonly project_key
 # Run the Sonar Scanner in a container. The "repository" directory is just the
 # source code, and we mount it to be able to scan the source code.
 #
-# Should we be running on main, then skip passing the information regarding the
-# pull request.
+# Should we be running on master, then skip passing the information regarding
+# the pull request.
 #
 # Finally, the volume is mounted with the "z" option, because it seems like
 # the runner has SELinux activated, and that we need to relabel the directory
 # to have permission to read it. More information here: https://www.reddit.com/r/podman/comments/fww87v/permission_denied_within_mounted_volume_inside/
 #
-if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "origin/main" ]; then
+if [ -n "${GIT_BRANCH:-}" ] && { [ "${GIT_BRANCH}" == "master" ] || [ "${GIT_BRANCH}" == "origin/master" ]; }; then
   podman run \
     --env COMMIT_SHORT="${commit_short}" \
     --env GIT_BRANCH="${GIT_BRANCH}" \


### PR DESCRIPTION
The main branch in this repository is called "master", and since the
scripts had the main branch as "main", SonarQube was not analyzing the
main branch of the repository to make comparisons.

## Jira ticket
[[RHCLOUD-39380]](https://issues.redhat.com/browse/RHCLOUD-39380)