### PR TITLE
RHCLOUD-35843 | fix: pods get restarted by Kubernetes very often

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -63,7 +63,7 @@ objects:
               - stat
               - /tmp/healthy
           initialDelaySeconds: 10
-          periodSeconds: 10
+          periodSeconds: 60
     kafkaTopics:
     - topicName: platform.sources.superkey-requests
       partitions: 3


### PR DESCRIPTION
The Superkey worker was pinging AWS as a way to perform liveness checks, but that was not a good way to determine the pod's health.

In fact, the pod's health should come determined by the errors we receive by the Kafka client or the REST integration with Sources. However, that would require a considerable refactor of the structure of the code, so we are just going to remove the faulty liveness probe for now and create the tickets for scheduling the refactor work.

## Jira ticket
[[RHCLOUD-35843]](https://issues.redhat.com/browse/RHCLOUD-35843)