### PR TITLE
Update dependency github.com/RedHatInsights/konflux-pipelines to v1.71.0

### DIFF
--- a/.tekton/sources-superkey-worker-pull-request.yaml
+++ b/.tekton/sources-superkey-worker-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: sources

--- a/.tekton/sources-superkey-worker-push.yaml
+++ b/.tekton/sources-superkey-worker-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: sources


### PR DESCRIPTION
## Summary
- Update `pipelinesascode.tekton.dev/pipeline` from konflux-pipelines v1.70.0 to v1.71.0 in both push and pull-request Tekton PipelineRun configs

## Test plan
- [ ] Verify push pipeline triggers correctly with the new pipeline version
- [ ] Verify pull-request pipeline triggers correctly with the new pipeline version

🤖 Generated with [Claude Code](https://claude.com/claude-code)