### PR TITLE
build(tekton): bump konflux-pipelines from v1.71.0 to v1.72.0

### DIFF
--- a/.tekton/sources-superkey-worker-pull-request.yaml
+++ b/.tekton/sources-superkey-worker-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.72.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: sources

--- a/.tekton/sources-superkey-worker-push.yaml
+++ b/.tekton/sources-superkey-worker-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.72.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: sources


### PR DESCRIPTION
This PR updates the konflux-pipelines reference in the Tekton pipeline configurations.

| Package | Type | Update | Change |
|---|---|---|---|
| [github.com/RedHatInsights/konflux-pipelines](https://github.com/RedHatInsights/konflux-pipelines) | tekton-annotation | minor | `v1.71.0` → `v1.72.0` |

---

### Changes

Updates the `pipelinesascode.tekton.dev/pipeline` annotation in:
- `.tekton/sources-superkey-worker-pull-request.yaml`
- `.tekton/sources-superkey-worker-push.yaml`

### Release Notes

See [v1.72.0 release notes](https://github.com/RedHatInsights/konflux-pipelines/releases/tag/v1.72.0) for details on what's included in this update.